### PR TITLE
bug fix for Have the query_creator script create a 'queries' director…

### DIFF
--- a/scripts/query_creator.py
+++ b/scripts/query_creator.py
@@ -85,6 +85,8 @@ urls = [
 
 def createQuery(title, short_title, url, show_summary):
     file_name = queries_dir + str(datetime.date.today()) + '_' + short_title
+    if not os.path.exists(queries_dir):
+        os.makedirs(queries_dir)
     qf = open(file_name, 'w')
     qf.write("query_name = \'" + title + "\'\n")
     qf.write("query_url = \'" + url + "\'\n")


### PR DESCRIPTION
bug fix for Have the query_creator script create a 'queries' directory #7 

Fix for the following error:

python scripts/query_creator.py -d
Traceback (most recent call last):
  File "scripts/query_creator.py", line 125, in <module>
    queries = createQueriesList(print_all=options.queries_only)
  File "scripts/query_creator.py", line 102, in createQueriesList
    queries.append(createQuery(title=url[1][0], short_title=url[1][1], url=url[1][2], show_summary=url[1][3]))
  File "scripts/query_creator.py", line 90, in createQuery
    qf = open(file_name, 'w')
IOError: [Errno 21] Is a directory:

