### PR TITLE
Fix for hide bugzilla user & password in any and all output from scripts #8 

### DIFF
--- a/bugzilla/agents.py
+++ b/bugzilla/agents.py
@@ -30,7 +30,9 @@ class BugzillaAgent(object):
         try:
             return Bug.get(url)
         except Exception, e:
-            pattern = re.compile(r"https://bugzilla.mozilla.org*.+&api_key=(.*?)&")
+            pattern = re.compile(
+                    r"https://bugzilla.mozilla.org*.+&api_key=(.*?)&"
+            )
             api_key = pattern.findall(e.message)[0]
             error = e.message.replace(api_key, '*'*len(api_key))
             raise Exception(error)    
@@ -40,7 +42,9 @@ class BugzillaAgent(object):
         try:
             return BugSearch.get(url).bugs
         except Exception, e:
-            pattern = re.compile(r"https://bugzilla.mozilla.org*.+&api_key=(.*?)&")
+            pattern = re.compile(
+                    r"https://bugzilla.mozilla.org*.+&api_key=(.*?)&"
+            )
             api_key = pattern.findall(e.message)[0]
             error = e.message.replace(api_key, '*'*len(api_key))
             raise Exception(error)

--- a/bugzilla/agents.py
+++ b/bugzilla/agents.py
@@ -1,4 +1,5 @@
 import os
+import re
 from bugzilla.models import BugSearch, Bug
 from bugzilla.utils import urljoin, qs
 
@@ -26,11 +27,23 @@ class BugzillaAgent(object):
         params['exclude_fields'] = [exclude_fields]
 
         url = urljoin(self.API_ROOT, 'bug/%s?%s' % (bug, self.qs(**params)))
-        return Bug.get(url)
+        try:
+            return Bug.get(url)
+        except Exception, e:
+            pattern = re.compile(r"https://bugzilla.mozilla.org*.+&api_key=(.*?)&")
+            api_key = pattern.findall(e.message)[0]
+            error = e.message.replace(api_key, '*'*len(api_key))
+            raise Exception(error)    
 
     def get_bug_list(self, params={}):
         url = urljoin(self.API_ROOT, 'bug/?%s' % (self.qs(**params)))
-        return BugSearch.get(url).bugs
+        try:
+            return BugSearch.get(url).bugs
+        except Exception, e:
+            pattern = re.compile(r"https://bugzilla.mozilla.org*.+&api_key=(.*?)&")
+            api_key = pattern.findall(e.message)[0]
+            error = e.message.replace(api_key, '*'*len(api_key))
+            raise Exception(error)
 
     def qs(self, **params):
         if self.api_key:


### PR DESCRIPTION
When ever an error occurs, From /usr/local/lib/python2.7/dist-packages/remoteobjects/http.py, it will get raised using err_cls. Example:

213 raise err_cls('%d %s requesting %s %s'
214 % (response.status, response.reason, classname, url))
215

We will replace such error urls's api_key with *** while printing in console.

Now sample error response will be:

File "test.py", line 21, in
buglist = bmo.get_bug_list(options)
File "/home/bztools/bugzilla/agents.py", line 46, in get_bug_list
raise Exception(error)
Exception: 400 Bad Request requesting BugSearch https://bugzilla.mozilla.org/bzapi/bug/?&changed_before=2010-12-26&product=Core,Firefox&changed_field=status&changed_after=2010-12-24&include_fields=_default,attachments&changed_field_to=RESOLVED&api_key=*****************************************&resolution=FIXED