### PR TITLE
fix for hide bugzilla user & password in any and all output from scri…

### DIFF
--- a/auto_nag/bugzilla/agents.py
+++ b/auto_nag/bugzilla/agents.py
@@ -1,6 +1,6 @@
 import os
 from auto_nag.bugzilla.models import BugSearch, Bug
-from auto_nag.bugzilla.utils import urljoin, qs
+from auto_nag.bugzilla.utils import urljoin, qs, hide_personal_info
 
 
 class InvalidAPI_ROOT(Exception):
@@ -26,11 +26,17 @@ class BugzillaAgent(object):
         params['exclude_fields'] = [exclude_fields]
 
         url = urljoin(self.API_ROOT, 'bug/%s?%s' % (bug, self.qs(**params)))
-        return Bug.get(url)
+        try:
+            return Bug.get(url)
+        except Exception, e:
+            raise Exception(hide_personal_info(str(e)))
 
     def get_bug_list(self, params={}):
         url = urljoin(self.API_ROOT, 'bug/?%s' % (self.qs(**params)))
-        return BugSearch.get(url).bugs
+        try:
+            return BugSearch.get(url).bugs
+        except Exception, e:
+            raise Exception(hide_personal_info(str(e)))
 
     def qs(self, **params):
         if self.api_key:

--- a/auto_nag/bugzilla/utils.py
+++ b/auto_nag/bugzilla/utils.py
@@ -2,6 +2,7 @@ import base64
 from ConfigParser import ConfigParser
 import getpass
 import os
+import re
 import posixpath
 import urllib
 
@@ -26,6 +27,15 @@ def get_config_path():
 def urljoin(base, *args):
     """Remove any leading slashes so no subpaths look absolute."""
     return posixpath.join(base, *[str(s).lstrip('/') for s in args])
+
+
+def hide_personal_info(error):
+    """ Hides bugzilla user information from remoteobject error"""
+    pattern = re.compile(
+        r"https://bugzilla.mozilla.org*.+&api_key=(.*?)&")
+    api_key = pattern.findall(error)[0]
+    error_msg = error.replace(api_key, '*' * len(api_key))
+    return error_msg
 
 
 def qs(**kwargs):

--- a/auto_nag/tests/test_utils.py
+++ b/auto_nag/tests/test_utils.py
@@ -2,23 +2,41 @@
 try:
     # If relman-auto-nag is installed
     from auto_nag.bugzilla.utils import os
-    from auto_nag.bugzilla.utils import get_project_root_path, get_config_path
+    from auto_nag.bugzilla.utils import get_project_root_path, \
+        get_config_path, hide_personal_info
 except:
     # If relman-auto-nag not installed, add project root directory into
     # PYTHONPATH
     import os
+    import inspect
+    import sys
     currentdir = os.path.dirname(os.path.abspath(
                                  inspect.getfile(inspect.currentframe())))
     parentdir = os.path.dirname(currentdir)
     sys.path.insert(0, parentdir)
-    from auto_nag.bugzilla.utils import get_project_root_path, get_config_path
+    from auto_nag.bugzilla.utils import get_project_root_path, \
+        get_config_path, hide_personal_info
+
+from nose.tools import raises
+
 
 class TestUtils:
     def test_get_project_root_path(self):
-         rpath = get_project_root_path()
-         assert os.path.isdir(rpath)
+        rpath = get_project_root_path()
+        assert os.path.isdir(rpath)
+
     def test_get_config_path(self):
         cpath = get_config_path()
         # remove 'not' when running locally
         # 'not' helps to pass CI checks while commiting
         assert not os.path.exists(cpath)
+
+    @raises(Exception)
+    def test_hide_personal_info():
+        sample_exception = "Exception: 400 Bad Request requesting " + \
+            "BugSearch https://bugzilla.mozilla.org/bzapi/bug/?&" + \
+            "changed_before=2010-12-26&product=Core,Firefox&" + \
+            "changed_field=status&changed_after=2010-12-24&" + \
+            "include_fields=_default,attachments&changed_field_to=" + \
+            "RESOLVED&api_key=xyzxyzxyz&resolution=FIXED"
+        hide_personal_info(sample_exception)

--- a/auto_nag/tests/test_utils.py
+++ b/auto_nag/tests/test_utils.py
@@ -17,8 +17,6 @@ except:
     from auto_nag.bugzilla.utils import get_project_root_path, \
         get_config_path, hide_personal_info
 
-from nose.tools import raises
-
 
 class TestUtils:
     def test_get_project_root_path(self):
@@ -31,12 +29,11 @@ class TestUtils:
         # 'not' helps to pass CI checks while commiting
         assert not os.path.exists(cpath)
 
-    @raises(Exception)
-    def test_hide_personal_info():
+    def test_hide_personal_info(self):
         sample_exception = "Exception: 400 Bad Request requesting " + \
             "BugSearch https://bugzilla.mozilla.org/bzapi/bug/?&" + \
             "changed_before=2010-12-26&product=Core,Firefox&" + \
             "changed_field=status&changed_after=2010-12-24&" + \
             "include_fields=_default,attachments&changed_field_to=" + \
             "RESOLVED&api_key=xyzxyzxyz&resolution=FIXED"
-        hide_personal_info(sample_exception)
+        assert "xyzxyzxyz" not in hide_personal_info(sample_exception)


### PR DESCRIPTION
When ever an error occurs, From /usr/local/lib/python2.7/dist-packages/remoteobjects/http.py,  error will get raised using err_cls. Example:

raise err_cls('%d %s requesting %s %s'
response.status, response.reason, classname, url))

We will replace such error urls's api_key with *** while printing in console.

Now sample error response will be:

File "test.py", line 21, in
buglist = bmo.get_bug_list(options)
File "/home/bztools/bugzilla/agents.py", line 46, in get_bug_list
raise Exception(error)
Exception: 400 Bad Request requesting BugSearch https://bugzilla.mozilla.org/bzapi/bug/?&changed_before=2010-12-26&product=Core,Firefox&changed_field=status&changed_after=2010-12-24&include_fields=_default,attachments&changed_field_to=RESOLVED&api_key=*****************************************&resolution=FIXED

