### PR TITLE
Bztools nosetests phonebook

### DIFF
--- a/auto_nag/tests/test_phonebook.py
+++ b/auto_nag/tests/test_phonebook.py
@@ -1,14 +1,26 @@
 
-import datetime
-
-from auto_nag.bugzilla.utils import get_project_root_path
-from auto_nag.bugzilla.agents import BMOAgent
 from auto_nag.scripts.phonebook import PhonebookDirectory
 
 
 class TestPhonebook:
+    def __init__(self):
+        self.demo_dict = {u'email@example.com': {
+                          u'bugzillaEmail': u'email@example.com',
+                          u'name': u'name',
+                          u'title': u'vice/director test',
+                          u'phones': u'string of numbers & assignments',
+                          u'ext': u'XXX',
+                          u'manager': {
+                                    u'dn': u'mail=manager@mozilla.com,o=com,dc=mozilla',
+                                    u'cn': u'Manager Name'
+                          },
+                          u'ims': [],
+                          u'mozillaMail': u'email'}}
+
     def test_init(self):
         pd = PhonebookDirectory(dryrun=True)
-        assert pd.people_by_bzmail
-        assert pd.managers
-        assert pd.vices
+        assert not len(set(self.demo_dict) ^ set(pd.people_by_bzmail))
+        assert not len(set(pd.managers['email']) ^
+                       set(self.demo_dict['email@example.com']))
+        assert not len(set(pd.vices['email']) ^
+                       set(self.demo_dict['email@example.com']))


### PR DESCRIPTION
@sylvestre 

The self.demo_dict we treat as a primary Dict, if there is any mess up in the people.json, we could catch it with this. 

by the way phonebook.py is just reading that people.json and processing it. In tests also if we are doing the same, then there is no pint in testing. Isn't it?

We  make sure that people.json processing done by Phonebook is correct by comparing this dict(self.demo_dict) with the desired output; Kind of testing the methods and Testing the people.json also :) 