### PR TITLE
BUG #2 : BzAPI server on which your software depends is going away

### DIFF
--- a/auto_nag/scripts/attach.py
+++ b/auto_nag/scripts/attach.py
@@ -129,7 +129,7 @@ def main():
 
     # Get the API root, default to bugzilla.mozilla.org
     API_ROOT = os.environ.get('BZ_API_ROOT',
-                              'https://api-dev.bugzilla.mozilla.org/latest/')
+                              'https://bugzilla.mozilla.org/bzapi/')
 
     # Authenticate
     username, password = get_credentials()


### PR DESCRIPTION
@sylvestre  This is the only place we are using old API