### PR TITLE
Show summary for non-restricted bugs

### DIFF
--- a/auto_nag/bugzilla/utils.py
+++ b/auto_nag/bugzilla/utils.py
@@ -123,14 +123,13 @@ FILE_TYPES = {
 }
 
 
-def createQuery(queries_dir, title, short_title, url, show_summary):
+def createQuery(queries_dir, title, short_title, url):
     file_name = queries_dir + str(datetime.date.today()) + '_' + short_title
     if not os.path.exists(queries_dir):
         os.makedirs(queries_dir)
     qf = open(file_name, 'w')
     qf.write("query_name = \'" + title + "\'\n")
     qf.write("query_url = \'" + url + "\'\n")
-    qf.write("show_summary = \'" + str(show_summary) + "\'\n")
     return file_name
 
 
@@ -138,11 +137,11 @@ def createQueriesList(queries_dir, weekday, urls, print_all):
     queries = []
     for url in urls:
         if weekday >= 0 and weekday < 5 and url[0] == 5:
-            queries.append(createQuery(queries_dir, title=url[1][0], short_title=url[1][1], url=url[1][2], show_summary=url[1][3]))
+            queries.append(createQuery(queries_dir, title=url[1][0], short_title=url[1][1], url=url[1][2]))
         if weekday == 0 and url[0] == 0:
-            queries.append(createQuery(queries_dir, title=url[1][0], short_title=url[1][1], url=url[1][2], show_summary=url[1][3]))
+            queries.append(createQuery(queries_dir, title=url[1][0], short_title=url[1][1], url=url[1][2]))
         if weekday == 3 and url[0] == 3:
-            queries.append(createQuery(queries_dir, title=url[1][0], short_title=url[1][1], url=url[1][2], show_summary=url[1][3]))
+            queries.append(createQuery(queries_dir, title=url[1][0], short_title=url[1][1], url=url[1][2]))
     print queries
     return queries
 

--- a/auto_nag/scripts/email_nag.py
+++ b/auto_nag/scripts/email_nag.py
@@ -88,13 +88,11 @@ def generateEmailOutput(subject, queries, template, people, show_comment=False,
             template_params[query] = {'buglist': []}
         if len(queries[query]['bugs']) != 0:
             for bug in queries[query]['bugs']:
-                if 'show_summary' in queries[query]:
-                    if queries[query]['show_summary'] == '1':
-                        summary = bug.summary
-                    else:
-                        summary = ""
+                if 'groups' in bug.to_dict():
+                    # probably a security bug, don't leak the summary
+                    summary = ''
                 else:
-                    summary = ""
+                    summary = bug.summary
                 template_params[query]['buglist'].append(
                     {
                         'id': bug.id,
@@ -257,7 +255,6 @@ if __name__ == '__main__':
                 collected_queries[query_name] = {
                     'channel': info.get('query_channel', ''),
                     'bugs': [],
-                    'show_summary': info.get('show_summary', 0),
                     'cclist': options.email_cc_list,
                     }
             if 'cc' in info:
@@ -291,7 +288,6 @@ if __name__ == '__main__':
         if manager_email not in managers:
             managers[manager_email] = {}
             managers[manager_email]['nagging'] = {query: {'bugs': [bug],
-                                                          'show_summary': info.get('show_summary', 0),
                                                           'cclist': info.get('cclist', [])}, }
             return
         if 'nagging' in managers[manager_email]:
@@ -303,7 +299,6 @@ if __name__ == '__main__':
             else:
                 managers[manager_email]['nagging'][query] = {
                     'bugs': [bug],
-                    'show_summary': info.get('show_summary', 0),
                     'cclist': info.get('cclist', [])
                 }
                 if options.verbose:
@@ -311,7 +306,6 @@ if __name__ == '__main__':
                      and %s" % (query, bug.id, manager_email)
         else:
             managers[manager_email]['nagging'] = {query: {'bugs': [bug],
-                                                          'show_summary': info.get('show_summary', 0),
                                                           'cclist': info.get('cclist', [])}, }
             if options.verbose:
                 print "Creating query key %s for bug %s in nagging and \
@@ -319,7 +313,7 @@ if __name__ == '__main__':
 
     for query, info in collected_queries.items():
         if len(collected_queries[query]['bugs']) != 0:
-            manual_notify[query] = {'bugs': [], 'show_summary': info.get('show_summary', 0)}
+            manual_notify[query] = {'bugs': [],}
             for b in collected_queries[query]['bugs']:
                 counter = counter + 1
                 send_mail = True
@@ -487,7 +481,12 @@ if __name__ == '__main__':
                         if k not in msg_body:
                             msg_body += "\n=== %s ===\n" % k
                         emailed_bugs.append(bug.id)
-                        msg_body += "http://bugzil.la/" + "%s -- assigned to: %s\n -- Last commented on: %s\n" % (bug.id, bug.assigned_to.real_name, bug.comments[-1].creation_time.replace(tzinfo=None))
+                        if 'groups' in bug.to_dict():
+                            summary = ''
+                        else:
+                            summary = ' %s\n' % bug.summary
+                        msg_body += "http://bugzil.la/%s -- assigned to: %s\n%s-- Last commented on: %s\n" % (
+                                bug.id, bug.assigned_to.real_name, summary, bug.comments[-1].creation_time.replace(tzinfo=None))
                     msg = ("From: %s\r\n" % REPLY_TO_EMAIL +
                            "To: %s\r\n" % REPLY_TO_EMAIL +
                            "Subject: RelMan Attention Needed: %s\r\n" % options.email_subject +

--- a/auto_nag/scripts/email_nag.py
+++ b/auto_nag/scripts/email_nag.py
@@ -313,7 +313,7 @@ if __name__ == '__main__':
 
     for query, info in collected_queries.items():
         if len(collected_queries[query]['bugs']) != 0:
-            manual_notify[query] = {'bugs': [],}
+            manual_notify[query] = {'bugs': []}
             for b in collected_queries[query]['bugs']:
                 counter = counter + 1
                 send_mail = True

--- a/auto_nag/scripts/query_creator.py
+++ b/auto_nag/scripts/query_creator.py
@@ -62,20 +62,20 @@ needinfo_esr45_url = "https://bugzilla.mozilla.org/buglist.cgi?f1=cf_tracking_fi
 # need same but for untouched
 
 urls = [
-    (5, ["Unlanded Beta " + beta_version + " Bugs", "unlanded_beta", unlanded_beta_url, 0]),
-    (5, ["Unlanded Aurora " + aurora_version + " Bugs", "unlanded_aurora", unlanded_aurora_url, 0]),
-    (5, ["Unlanded ESR45 Bugs", "unlanded_esr45", unlanded_esr45_url, 0]),
-    (5, ["Tracked or Nominated for Tracking with Need-Info? Beta " + beta_version + " Bugs", "needinfo_beta", needinfo_beta_url, 0]),
-    (5, ["Tracked or Nominated for Tracking with Need-Info? Aurora " + aurora_version + " Bugs", "needinfo_aurora", needinfo_aurora_url, 0]),
-    (5, ["Tracked or Nominated for Tracking with Need-Info? Nightly " + central_version + " Bugs", "needinfo_central", needinfo_central_url, 0]),
-    (5, ["Tracked or Nominated for Tracking with Need-Info? ESR45 Bugs", "needinfo_esr45", needinfo_esr45_url, 0]),
-    (0, ["Bugs Tracked for Beta " + beta_version, "tracking_beta", tracking_beta_url, 0]),
-    (0, ["Bugs Tracked for Aurora " + aurora_version, "tracking_aurora", tracking_aurora_url, 0]),
-    (0, ["Bugs Tracked for Nightly " + central_version, "tracking_central", tracking_central_url, 0]),
-    (0, ["Bugs Tracked for ESR45", "tracking_esr45", tracking_esr45_url, 0]),
-    (3, ["Tracked Beta " + beta_version + " Bugs, untouched this week", "untouched_tracking_beta", tracking_beta_touch_url, 0]),
-    (3, ["Tracked Aurora " + aurora_version + " Bugs, untouched this week", "untouched_tracking_aurora", tracking_aurora_touch_url, 0]),
-    (3, ["Tracked Nightly " + central_version + " Bugs, untouched this week", "untouched_tracking_nightly", tracking_central_touch_url, 0])
+    (5, ["Unlanded Beta " + beta_version + " Bugs", "unlanded_beta", unlanded_beta_url]),
+    (5, ["Unlanded Aurora " + aurora_version + " Bugs", "unlanded_aurora", unlanded_aurora_url]),
+    (5, ["Unlanded ESR45 Bugs", "unlanded_esr45", unlanded_esr45_url]),
+    (5, ["Tracked or Nominated for Tracking with Need-Info? Beta " + beta_version + " Bugs", "needinfo_beta", needinfo_beta_url]),
+    (5, ["Tracked or Nominated for Tracking with Need-Info? Aurora " + aurora_version + " Bugs", "needinfo_aurora", needinfo_aurora_url]),
+    (5, ["Tracked or Nominated for Tracking with Need-Info? Nightly " + central_version + " Bugs", "needinfo_central", needinfo_central_url]),
+    (5, ["Tracked or Nominated for Tracking with Need-Info? ESR45 Bugs", "needinfo_esr45", needinfo_esr45_url]),
+    (0, ["Bugs Tracked for Beta " + beta_version, "tracking_beta", tracking_beta_url]),
+    (0, ["Bugs Tracked for Aurora " + aurora_version, "tracking_aurora", tracking_aurora_url]),
+    (0, ["Bugs Tracked for Nightly " + central_version, "tracking_central", tracking_central_url]),
+    (0, ["Bugs Tracked for ESR45", "tracking_esr45", tracking_esr45_url]),
+    (3, ["Tracked Beta " + beta_version + " Bugs, untouched this week", "untouched_tracking_beta", tracking_beta_touch_url]),
+    (3, ["Tracked Aurora " + aurora_version + " Bugs, untouched this week", "untouched_tracking_aurora", tracking_aurora_touch_url]),
+    (3, ["Tracked Nightly " + central_version + " Bugs, untouched this week", "untouched_tracking_nightly", tracking_central_touch_url])
 ]
 
 

--- a/auto_nag/scripts/rm_query_creator.py
+++ b/auto_nag/scripts/rm_query_creator.py
@@ -16,7 +16,7 @@ fixed_without_uplifts_url = "https://bugzilla.mozilla.org/buglist.cgi?v4=affecte
 # TODO - fix the 'untouched' queries
 
 urls = [
-    (5, ["Notify release managers when bugs are marked fixed in nightly but still affected for aurora, beta or release", "fixed_without_uplifts", fixed_without_uplifts_url, 1])
+    (5, ["Notify release managers when bugs are marked fixed in nightly but still affected for aurora, beta or release", "fixed_without_uplifts", fixed_without_uplifts_url])
 ]
 
 

--- a/auto_nag/tests/test_email_nag.py
+++ b/auto_nag/tests/test_email_nag.py
@@ -1,8 +1,9 @@
 
 import datetime
 
-from auto_nag.bugzilla.utils import get_project_root_path
+from auto_nag.bugzilla.utils import get_project_root_path, getVersions
 from auto_nag.bugzilla.agents import BMOAgent
+from auto_nag.bugzilla.models import Bug
 from auto_nag.scripts.phonebook import PhonebookDirectory
 from auto_nag.scripts.email_nag import (get_last_manager_comment,
                                         get_last_assignee_comment,
@@ -15,6 +16,14 @@ class TestEmailNag:
         bmo = BMOAgent()
         self.bug = bmo.get_bug(bug_number)
         self.people = PhonebookDirectory(dryrun=True)
+        hidden_dict = {
+                'id': 123456,
+                'summary': 'hide me',
+                'assigned_to': {'real_name': 'nobody'},
+                'groups': [{'name': 'security group'}]}
+        hidden_dict.update({'cf_status_firefox' + version: '---'
+                            for version in getVersions()})
+        self.hidden_bug = Bug.from_dict(hidden_dict)
         assignee = 'email@example.com'
         self.manager = {'mozillaMail': 'test@mozilla.com',
                         'bugzillaEmail': 'demo@bugzilla.com'}
@@ -39,6 +48,15 @@ class TestEmailNag:
                                                self.people, False,
                                                'Test@test.com')
         contents = ('From', 'To', 'CC', 'Subject:', '= Next Actions =',
+                    '= Queries =', 'Sincerely,', self.bug.summary)
+        assert '@' in toaddrs[0]
+        assert all(content in message for content in contents)
+        query = {'Test': {'bugs': [self.hidden_bug]}}
+        toaddrs, message = generateEmailOutput('Test', query, 'daily_email',
+                                               self.people, False,
+                                               'Test@test.com')
+        contents = ('From', 'To', 'CC', 'Subject:', '= Next Actions =',
                     '= Queries =', 'Sincerely,')
         assert '@' in toaddrs[0]
         assert all(content in message for content in contents)
+        assert self.hidden_bug.summary not in message

--- a/auto_nag/tests/test_email_nag.py
+++ b/auto_nag/tests/test_email_nag.py
@@ -34,7 +34,7 @@ class TestEmailNag:
         assert isinstance(lac, (datetime.datetime))
 
     def test_generateEmailOutput(self):
-        query = {'Test': {'bugs': [self.bug], 'show_summary': '0'}}
+        query = {'Test': {'bugs': [self.bug]}}
         toaddrs, message = generateEmailOutput('Test', query, 'daily_email',
                                                self.people, False,
                                                'Test@test.com')


### PR DESCRIPTION
Instead of a per-query show_summary boolean, check whether each bug is
restricted to a particular group, and include the title in the nag email
if not.

This also means the summary won't be shown anymore for restricted bugs
in the RelMan "fixed without uplifts" status mail.

Closes mozilla/relman-auto-nag#68