### PR TITLE
Fix sorting by affected versions

### DIFF
--- a/auto_nag/scripts/email_nag.py
+++ b/auto_nag/scripts/email_nag.py
@@ -123,7 +123,7 @@ def generateEmailOutput(subject, queries, template, people, show_comment=False,
                     addToAddrs(bug)
 
     # Order by versions
-    if 'affected' in template_params[query]['buglist']:
+    if 'affected' in template_params[query]['buglist'][0]:
         template_params[query]['buglist'] = sorted(template_params[query]['buglist'], key=lambda p: p['affected'][0])
 
     message_body = template.render(queries=template_params, show_comment=show_comment)

--- a/auto_nag/scripts/email_nag.py
+++ b/auto_nag/scripts/email_nag.py
@@ -124,7 +124,7 @@ def generateEmailOutput(subject, queries, template, people, show_comment=False,
 
     # Order by versions
     if 'affected' in template_params[query]['buglist'][0]:
-        template_params[query]['buglist'] = sorted(template_params[query]['buglist'], key=lambda p: p['affected'][0])
+        template_params[query]['buglist'] = sorted(template_params[query]['buglist'], key=lambda p: p['affected'] and p['affected'][0])
 
     message_body = template.render(queries=template_params, show_comment=show_comment)
     if manager_email is not None and manager_email not in cclist:


### PR DESCRIPTION
template_params[query]['buglist'] is a list of dicts (one per bug), not
a dict.

This change assumes that if a bug dict has an 'affected' key, all of them do.