### PR TITLE
Fix NameError when we have a "next" ESR

### DIFF
--- a/auto_nag/scripts/query_creator.py
+++ b/auto_nag/scripts/query_creator.py
@@ -39,7 +39,9 @@ beta_version = getVersion(jsonContent, "LATEST_FIREFOX_DEVEL_VERSION")
 aurora_version = getVersion(jsonContent, "FIREFOX_AURORA")
 central_version = getVersion(jsonContent, "FIREFOX_NIGHTLY")
 esr_next_version = getVersion(jsonContent, "FIREFOX_ESR_NEXT")
-if not esr_next_version:
+if esr_next_version:
+    esr_version = esr_next_version
+else:
     # We are in a cycle where we don't have esr_next
     # For example, with 52.6, esr_next doesn't exist
     # But it will exist, once 60 is released


### PR DESCRIPTION
Fixes 0db6c130deba68800fad9e6cd9467ff5fb3ee5aa "Use product-details instead of
the wiki"