### PR TITLE
Remove no-longer-necessary hacks

### DIFF
--- a/auto_nag/scripts/email_nag.py
+++ b/auto_nag/scripts/email_nag.py
@@ -367,11 +367,6 @@ if __name__ == '__main__':
                     if 'nobody' in assignee:
                         if options.verbose:
                             print "No one assigned to: %s, will be in the manual notification list..." % bug.id
-                    # TODO - get rid of this, SUCH A HACK!
-                    elif 'general@js.bugs' in assignee:
-                        if options.verbose:
-                            print "No one assigned to JS bug: %s, adding to Naveed's list..." % bug.id
-                        add_to_managers('nihsanullah@mozilla.com', query, info)
                     else:
                         if bug.assigned_to.real_name is not None:
                             if person is not None:

--- a/auto_nag/scripts/phonebook.py
+++ b/auto_nag/scripts/phonebook.py
@@ -68,9 +68,7 @@ class PhonebookDirectory():
                 if 'director' in self.people[email]['title'].lower() or 'manager' in self.people[email]['title'].lower():
                     managers[email] = info
             # HACK! don't have titles with manager/director or missing bugmail address
-            if email in ('dtownsend@mozilla.com', 'dougt@mozilla.com',
-                         'mfinkle@mozilla.com', 'bsmedberg@mozilla.com',
-                         'blassey@mozilla.com') and email not in managers.keys():
+            if email == 'dtownsend@mozilla.com' and email not in managers.keys():
                 managers[email] = info
         return managers
 


### PR DESCRIPTION
Remove special cases for people who are no longer at Mozilla, and for the
"general@js.bugs" assignee which doesn't look like it's used nowadays.