### PR TITLE
Make sys.path hack in _get_credentials.py script slightly less horrible

### DIFF
--- a/auto_nag/tests/_get_credential.py
+++ b/auto_nag/tests/_get_credential.py
@@ -3,11 +3,9 @@
 import os
 import inspect
 import sys
-currentdir = os.path.dirname(os.path.abspath(
-                             inspect.getfile(inspect.currentframe())))
-parentdir = os.path.dirname(currentdir)
-util_dir = parentdir + '/bugzilla'
-sys.path.insert(0, util_dir)
-import utils
+currentdir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.dirname(os.path.dirname(currentdir))
+sys.path.insert(0, project_root)
+from auto_nag.bugzilla import utils
 
 utils.get_credentials()


### PR DESCRIPTION
Rather than adding the path to the auto_nag/bugzilla package to
sys.path, use the actual project root path, and then import stuff from
auto_nag.bugzilla.