### PR TITLE
Pass extra arguments from tox to the test command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ deps =
 
 commands =
     coverage erase
-    coverage run --branch --source {toxinidir}/auto_nag {envbindir}/nosetests -v --rednose --nocapture --force-color {toxinidir}/auto_nag
+    coverage run --branch --source {toxinidir}/auto_nag {envbindir}/nosetests -v --rednose --nocapture --force-color {toxinidir}/auto_nag {posargs}


### PR DESCRIPTION
Allows running e.g. "tox -- --pdb" to get extra args to nosetests.