### PR TITLE
bugzilla.utils: avoid IndexError while trying to hide API key from ex…

### DIFF
--- a/auto_nag/bugzilla/utils.py
+++ b/auto_nag/bugzilla/utils.py
@@ -40,8 +40,11 @@ def hide_personal_info(error):
     """ Hides bugzilla user information from remoteobject error"""
     pattern = re.compile(
         r"https://bugzilla.mozilla.org*.+&api_key=(.*?)&")
-    api_key = pattern.findall(error)[0]
-    error_msg = error.replace(api_key, '*' * len(api_key))
+    try:
+        api_key = pattern.findall(error)[0]
+        error_msg = error.replace(api_key, '*' * len(api_key))
+    except IndexError:
+        error_msg = error
     return error_msg
 
 


### PR DESCRIPTION
…ception

If the URL had no API key parameter, we would crash while trying to
handle e.g. an Unauthorized exception.