### PR TITLE
Handle groups and flags properly with bugzilla REST API

### DIFF
--- a/auto_nag/bugzilla/models.py
+++ b/auto_nag/bugzilla/models.py
@@ -104,7 +104,7 @@ class Bug(RemoteObject):
     actual_time = fields.Field()
     deadline = Datetime(DATETIME_FORMAT_WITH_SECONDS)
     estimated_time = fields.Field()
-    # groups = fields.Field() # unimplemented
+    groups = fields.List(fields.Field())
     percentage_complete = fields.Field()
     remaining_time = fields.Field()
     work_time = fields.Field()
@@ -227,9 +227,9 @@ class Flag(RemoteObject):
 
     id = fields.Field()
     name = fields.Field()
-    setter = fields.Object('User')
+    setter = fields.Field()
     status = fields.Field()
-    requestee = fields.Object('User')
+    requestee = fields.Field()
     type_id = fields.Field()
 
     def __repr__(self):

--- a/auto_nag/scripts/attach.py
+++ b/auto_nag/scripts/attach.py
@@ -46,7 +46,7 @@ class AttachmentAgent(BugzillaAgent):
 
         if reviewer is not None:
             fields['flags'] = [Flag(type_id=REVIEW, status='?',
-                                    requestee=User(name=reviewer))]
+                                    requestee=reviewer)]
 
         url = urljoin(self.API_ROOT, 'bug/%s/attachment?%s' % (bug_id, self.qs()))
         return Attachment(**fields).post_to(url)

--- a/auto_nag/scripts/attach.py
+++ b/auto_nag/scripts/attach.py
@@ -5,7 +5,7 @@ import itertools
 import os
 import argparse
 
-from auto_nag.bugzilla.models import Attachment, Flag, User, Comment
+from auto_nag.bugzilla.models import Attachment, Flag, Comment
 from auto_nag.bugzilla.agents import BugzillaAgent
 from auto_nag.bugzilla.utils import urljoin, get_credentials, FILE_TYPES
 

--- a/auto_nag/scripts/email_nag.py
+++ b/auto_nag/scripts/email_nag.py
@@ -90,7 +90,7 @@ def generateEmailOutput(subject, queries, template, people, show_comment=False,
                 template_params[query]['query_url'] = queries[query]['url']
         if len(queries[query]['bugs']) != 0:
             for bug in queries[query]['bugs']:
-                if bug.to_dict().get('groups', []):
+                if bug.groups:
                     # probably a security bug, don't leak the summary
                     summary = ''
                 else:
@@ -478,7 +478,7 @@ if __name__ == '__main__':
                         if k not in msg_body:
                             msg_body += "\n=== %s ===\n" % k
                         emailed_bugs.append(bug.id)
-                        if 'groups' in bug.to_dict():
+                        if bug.groups:
                             summary = ''
                         else:
                             summary = ' %s\n' % bug.summary


### PR DESCRIPTION
Like comment authors, flag setter and requestee are now plain strings
instead of User objects.  While I'm there, handle groups properly so we
don't treat all bugs as restricted.