### PR TITLE
Add a config file for tools like no_assignee and leave_open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ bztools.egg-info/
 dist/
 queries/
 scripts/configs/config.json
-auto_nag/scripts/configs/
+auto_nag/scripts/configs/*
+!auto_nag/scripts/configs/tools.json

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -1,0 +1,20 @@
+{
+    "no_assignee":
+    {
+        "receivers":
+        [
+            "calixte@mozilla.com",
+            "sylvestre@mozilla.com"
+        ],
+        "days_lookup": 7
+    },
+    "leave_open":
+    {
+        "receivers":
+        [
+            "calixte@mozilla.com",
+            "sylvestre@mozilla.com"
+        ],
+        "days_lookup": 7
+    }
+}

--- a/auto_nag/scripts/leave_open.py
+++ b/auto_nag/scripts/leave_open.py
@@ -14,7 +14,7 @@ from auto_nag import mail, utils
 
 def get_bz_params(date):
     date = lmdutils.get_date_ymd(date)
-    lookup = utils.get_config('leave_open', 'days_lookup')
+    lookup = utils.get_config('leave_open', 'days_lookup', 7)
     start_date = date - relativedelta(days=lookup)
     end_date = date + relativedelta(days=1)
     fields = ['id']
@@ -73,7 +73,7 @@ def send_email(date='today', dryrun=False):
     title, body = get_email(login_info['bz_api_key'], date)
     if title:
         mail.send(login_info['ldap_username'],
-                  utils.get_config('leave_open', 'receivers'),
+                  utils.get_config('leave_open', 'receivers', ['sylvestre@mozilla.com']),
                   title, body,
                   html=True, login=login_info, dryrun=dryrun)
     else:

--- a/auto_nag/scripts/leave_open.py
+++ b/auto_nag/scripts/leave_open.py
@@ -9,15 +9,13 @@ import json
 from libmozdata.bugzilla import Bugzilla
 from libmozdata import utils as lmdutils
 from auto_nag.bugzilla.utils import get_config_path
-from auto_nag import mail
-
-
-TO = ['sylvestre@mozilla.com', 'calixte@mozilla.com']
+from auto_nag import mail, utils
 
 
 def get_bz_params(date):
     date = lmdutils.get_date_ymd(date)
-    start_date = date - relativedelta(days=7)
+    lookup = utils.get_config('leave_open', 'days_lookup')
+    start_date = date - relativedelta(days=lookup)
     end_date = date + relativedelta(days=1)
     fields = ['id']
     params = {'include_fields': fields,
@@ -74,7 +72,9 @@ def send_email(date='today', dryrun=False):
     date = lmdutils.get_date(date)
     title, body = get_email(login_info['bz_api_key'], date)
     if title:
-        mail.send(login_info['ldap_username'], TO, title, body,
+        mail.send(login_info['ldap_username'],
+                  utils.get_config('leave_open', 'receivers'),
+                  title, body,
                   html=True, login=login_info, dryrun=dryrun)
     else:
         print('LEAVE-OPEN: No data for {}'.format(date))

--- a/auto_nag/scripts/no_assignee.py
+++ b/auto_nag/scripts/no_assignee.py
@@ -11,15 +11,13 @@ from libmozdata.bugzilla import Bugzilla
 from libmozdata.connection import Query
 from libmozdata import hgmozilla, utils as lmdutils
 from auto_nag.bugzilla.utils import get_config_path
-from auto_nag import mail
-
-
-TO = ['sylvestre@mozilla.com', 'calixte@mozilla.com']
+from auto_nag import mail, utils
 
 
 def get_bz_params(date, bug_ids=[]):
     date = lmdutils.get_date_ymd(date)
-    start_date = date - relativedelta(days=7)
+    lookup = utils.get_config('no_assignee', 'days_lookup')
+    start_date = date - relativedelta(days=lookup)
     end_date = date + relativedelta(days=1)
     fields = ['id']
     regexp = 'http[s]?://hg\.mozilla\.org/(releases/)?mozilla-[^/]+/rev/[0-9a-f]+' # NOQA
@@ -130,7 +128,9 @@ def send_email(date='today', dryrun=False):
     date = lmdutils.get_date(date)
     title, body = get_email(login_info['bz_api_key'], date)
     if title:
-        mail.send(login_info['ldap_username'], TO, title, body,
+        mail.send(login_info['ldap_username'],
+                  utils.get_config('no_assignee', 'receivers'),
+                  title, body,
                   html=True, login=login_info, dryrun=dryrun)
     else:
         print('NO-ASSIGNEE: No data for {}'.format(date))

--- a/auto_nag/scripts/no_assignee.py
+++ b/auto_nag/scripts/no_assignee.py
@@ -16,7 +16,7 @@ from auto_nag import mail, utils
 
 def get_bz_params(date, bug_ids=[]):
     date = lmdutils.get_date_ymd(date)
-    lookup = utils.get_config('no_assignee', 'days_lookup')
+    lookup = utils.get_config('no_assignee', 'days_lookup', 7)
     start_date = date - relativedelta(days=lookup)
     end_date = date + relativedelta(days=1)
     fields = ['id']
@@ -129,7 +129,7 @@ def send_email(date='today', dryrun=False):
     title, body = get_email(login_info['bz_api_key'], date)
     if title:
         mail.send(login_info['ldap_username'],
-                  utils.get_config('no_assignee', 'receivers'),
+                  utils.get_config('no_assignee', 'receivers', ['sylvestre@mozilla.com']),
                   title, body,
                   html=True, login=login_info, dryrun=dryrun)
     else:

--- a/auto_nag/utils.py
+++ b/auto_nag/utils.py
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+
+
+_CONFIG = None
+
+
+def _get_config():
+    global _CONFIG
+    if _CONFIG is None:
+        with open('./auto_nag/scripts/configs/tools.json', 'r') as In:
+            _CONFIG = json.load(In)
+    return _CONFIG
+
+
+def get_config(name, entry):
+    conf = _get_config()
+    return conf.get(name, {}).get(entry)

--- a/auto_nag/utils.py
+++ b/auto_nag/utils.py
@@ -11,11 +11,14 @@ _CONFIG = None
 def _get_config():
     global _CONFIG
     if _CONFIG is None:
-        with open('./auto_nag/scripts/configs/tools.json', 'r') as In:
-            _CONFIG = json.load(In)
+        try:
+            with open('./auto_nag/scripts/configs/tools.json', 'r') as In:
+                _CONFIG = json.load(In)
+        except IOError:
+            _CONFIG = {}
     return _CONFIG
 
 
-def get_config(name, entry):
+def get_config(name, entry, default):
     conf = _get_config()
-    return conf.get(name, {}).get(entry)
+    return conf.get(name, {}).get(entry, default)


### PR DESCRIPTION
Just add a file tools.json in auto_nag/scripts/configs which contains:
{
    "no_assignee":
    {
        "receivers":
        [
            "calixte@mozilla.com",
            "sylvestre@mozilla.com"
        ],
        "days_lookup": 7
    },
    "leave_open":
    {
        "receivers":
        [
            "calixte@mozilla.com",
            "sylvestre@mozilla.com"
        ],
        "days_lookup": 7
    }
}
