### PR TITLE
Refactor templates to separate common content from message

### DIFF
--- a/auto_nag/bzcleaner.py
+++ b/auto_nag/bzcleaner.py
@@ -148,9 +148,11 @@ class BzCleaner(object):
         if bugids:
             env = Environment(loader=FileSystemLoader('templates'))
             template = env.get_template(self.template())
-            body = template.render(date=date,
-                                   bugids=bugids,
-                                   extra=self.get_extra_for_template())
+            message = template.render(date=date,
+                                      bugids=bugids,
+                                      extra=self.get_extra_for_template())
+            common = env.get_template('common.html')
+            body = common.render(message=message)
             return self.get_email_subject(date), body
         return None, None
 

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -17,8 +17,7 @@
     {
         "receivers":
         [
-            "calixte@mozilla.com",
-            "sylvestre@mozilla.com"
+            "calixte@mozilla.com"
         ],
         "days_lookup": 7,
         "bz_query_timeout": 240,

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -17,7 +17,8 @@
     {
         "receivers":
         [
-            "calixte@mozilla.com"
+            "calixte@mozilla.com",
+            "sylvestre@mozilla.com"
         ],
         "days_lookup": 7,
         "bz_query_timeout": 240,

--- a/auto_nag/scripts/version_affected.py
+++ b/auto_nag/scripts/version_affected.py
@@ -16,6 +16,9 @@ class VersionAffected(BzCleaner):
 
     def description(self):
         return 'Bug with version set but not status_firefox'
+    
+    def (self):
+        return 'Bug with version set but not status_firefox'
 
     def name(self):
         return 'version_affected'

--- a/templates/assignee_but_unconfirmed.html
+++ b/templates/assignee_but_unconfirmed.html
@@ -1,23 +1,7 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Bugs where assigned but status=UNCONFIRMED</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs are assigned but status=UNCONFIRMED:
-      <ul>
-        {% for bugid, summary in bugids -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs are assigned but status=UNCONFIRMED:
+  <ul>
+    {% for bugid, summary in bugids -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
+    {% endfor -%}
+  </ul>
+</p>

--- a/templates/common.html
+++ b/templates/common.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <p>Hi there,</p>
+    {{ message }}
+    <p>Sincerely,<br>
+      Release Management Bot
+    </p>
+    <p>
+      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
+    </p>
+  </body>
+</html>

--- a/templates/feature_regression.html
+++ b/templates/feature_regression.html
@@ -1,23 +1,7 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Bugs with feature and regression keywords</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs have both regression and feature as keywords:
-      <ul>
-        {% for bugid in bugids -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs have both regression and feature as keywords:
+  <ul>
+    {% for bugid in bugids -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
+    {% endfor -%}
+  </ul>
+</p>

--- a/templates/has_reg_range_email.html
+++ b/templates/has_reg_range_email.html
@@ -1,23 +1,7 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Bugs with has_regression_range=yes but no regression keyword</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs have has_regression_range=yes but the regression keyword hasn't been set:
-      <ul>
-        {% for bugid in bugids -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs have has_regression_range=yes but the regression keyword hasn't been set:
+  <ul>
+    {% for bugid in bugids -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
+    {% endfor -%}
+  </ul>
+</p>

--- a/templates/leave_open_email.html
+++ b/templates/leave_open_email.html
@@ -1,23 +1,7 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Closed bugs with leave-open keyword</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs have been closed although the leave-open keyword is there:
-      <ul>
-        {% for bugid in bugids -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs have been closed although the leave-open keyword is there:
+  <ul>
+    {% for bugid in bugids -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
+    {% endfor -%}
+  </ul>
+</p>

--- a/templates/meta_summary_missing.html
+++ b/templates/meta_summary_missing.html
@@ -1,23 +1,7 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Bugs with the meta keyword but not [meta] in the title</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs have meta keyword but not [meta] in the title:
-      <ul>
-        {% for bugid, summary in bugids -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs have meta keyword but not [meta] in the title:
+  <ul>
+    {% for bugid, summary in bugids -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
+    {% endfor -%}
+  </ul>
+</p>

--- a/templates/mismatch-priority-tracking.html
+++ b/templates/mismatch-priority-tracking.html
@@ -1,23 +1,7 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Bug tracked with a bad priority</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs are tracked but with a bad priority:
-      <ul>
-        {% for bugid in bugids -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs are tracked but with a bad priority:
+  <ul>
+    {% for bugid in bugids -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
+    {% endfor -%}
+  </ul>
+</p>

--- a/templates/no_assignee_email.html
+++ b/templates/no_assignee_email.html
@@ -1,33 +1,17 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Bugs with no assignees</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs have no assignees and a patch which landed in m-c:
-      <ul>
-        {% for bugid, email in bugids.items() -%}
-        {% if not email -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
-        {% endif -%}
-        {% endfor -%}
-      </ul>
-      and these one have been auto-fixed:
-      <ul>
-        {% for bugid, email in bugids.items() -%}
-        {% if email -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a> assigned to {{ email }}</li>
-        {% endif -%}
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs have no assignees and a patch which landed in m-c:
+  <ul>
+    {% for bugid, email in bugids.items() -%}
+    {% if not email -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
+    {% endif -%}
+    {% endfor -%}
+  </ul>
+  and these one have been auto-fixed:
+  <ul>
+    {% for bugid, email in bugids.items() -%}
+    {% if email -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a> assigned to {{ email }}</li>
+    {% endif -%}
+    {% endfor -%}
+  </ul>
+</p>

--- a/templates/no_crashes.html
+++ b/templates/no_crashes.html
@@ -1,23 +1,7 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Bugs with no crashes in last {{ extra['nweeks'] }} weeks</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs have no crashes in last {{ extra['nweeks'] }} weeks:
-      <ul>
-        {% for bugid in bugids -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs have no crashes in last {{ extra['nweeks'] }} weeks:
+  <ul>
+    {% for bugid in bugids -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
+    {% endfor -%}
+  </ul>
+</p>

--- a/templates/old_p1_bug.html
+++ b/templates/old_p1_bug.html
@@ -1,23 +1,7 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Get old P1 bugs with no activity for the last {{ extra['nweeks'] }} weeks</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs have a p1 priority but no activity activity in last {{ extra['nweeks'] }} weeks:
-      <ul>
-        {% for bugid, summary in bugids -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs have a p1 priority but no activity activity in last {{ extra['nweeks'] }} weeks:
+  <ul>
+    {% for bugid, summary in bugids -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
+    {% endfor -%}
+  </ul>
+</p>

--- a/templates/old_p2_bug.html
+++ b/templates/old_p2_bug.html
@@ -1,23 +1,7 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Get old P2 bugs with no activity for the last {{ extra['nyears'] }} year(s)</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs have a p2 priority but no activity activity in last {{ extra['nyears'] }} year()s:
-      <ul>
-        {% for bugid, summary in bugids -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs have a p2 priority but no activity activity in last {{ extra['nyears'] }} year()s:
+  <ul>
+    {% for bugid, summary in bugids -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
+    {% endfor -%}
+  </ul>
+</p>

--- a/templates/one_two_word_summary.html
+++ b/templates/one_two_word_summary.html
@@ -1,23 +1,7 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Bugs only one or two words in the summary</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs have only one or two words in the summary:
-      <ul>
-        {% for bugid, summary in bugids -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs have only one or two words in the summary:
+  <ul>
+    {% for bugid, summary in bugids -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
+    {% endfor -%}
+  </ul>
+</p>

--- a/templates/regression.html
+++ b/templates/regression.html
@@ -1,23 +1,7 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Bugs with missing regression keyword</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs are probably a regression and don't have regression keyword:
-      <ul>
-        {% for bugid, summary in bugids -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs are probably a regression and don't have regression keyword:
+  <ul>
+    {% for bugid, summary in bugids -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
+    {% endfor -%}
+  </ul>
+</p>

--- a/templates/reporter_with_ni.html
+++ b/templates/reporter_with_ni.html
@@ -1,23 +1,7 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Bugs where the reporter has a needinfo with no activity in last {{ extra['nweeks'] }} weeks</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs have a needinfo on the reporter and have no activity in last {{ extra['nweeks'] }} weeks:
-      <ul>
-        {% for bugid, summary in bugids -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs have a needinfo on the reporter and have no activity in last {{ extra['nweeks'] }} weeks:
+  <ul>
+    {% for bugid, summary in bugids -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
+    {% endfor -%}
+  </ul>
+</p>

--- a/templates/topcrash_bad_severity.html
+++ b/templates/topcrash_bad_severity.html
@@ -1,23 +1,7 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Bugs with topcrash keyword but incorrect severity</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs have topcrash as keyword but the severity isn't high enough:
-      <ul>
-        {% for bugid in bugids -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs have topcrash as keyword but the severity isn't high enough:
+  <ul>
+    {% for bugid in bugids -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
+    {% endfor -%}
+  </ul>
+</p>

--- a/templates/tracked-bad-severity.html
+++ b/templates/tracked-bad-severity.html
@@ -1,23 +1,7 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Bug tracked in a release but with a small severity</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs are tracked in a release but the bug severity is small:
-      <ul>
-        {% for bugid in bugids -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs are tracked in a release but the bug severity is small:
+  <ul>
+    {% for bugid in bugids -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
+    {% endfor -%}
+  </ul>
+</p>

--- a/templates/unaffected-affected-no-reg.html
+++ b/templates/unaffected-affected-no-reg.html
@@ -1,23 +1,7 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Bug not affecting the release but affecting beta or nightly without the regression keyword</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs does not affect the release but affect beta or nightly without the regression keyword:
-      <ul>
-        {% for bugid, summary in bugids -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs does not affect the release but affect beta or nightly without the regression keyword:
+  <ul>
+    {% for bugid, summary in bugids -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
+    {% endfor -%}
+  </ul>
+</p>

--- a/templates/untriage_important_sev.html
+++ b/templates/untriage_important_sev.html
@@ -1,23 +1,7 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Get bugs in untriagged with an important severity</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs are in untriagged with an important severity
-      <ul>
-        {% for bugid, summary in bugids -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs are in untriagged with an important severity
+  <ul>
+    {% for bugid, summary in bugids -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a>: {{ summary|e }}</li>
+    {% endfor -%}
+  </ul>
+</p>

--- a/templates/version_affected.html
+++ b/templates/version_affected.html
@@ -1,23 +1,7 @@
-<!doctype html>
-<html lang="en-us">
-  <head>
-    <meta charset="utf-8">
-    <title>[autonag] Bug with Version set but not status_firefox</title>
-  </head>
-  <body>
-    <p>Hi there,</p>
-    <p>The following bugs have Version set but not status_firefox:
-      <ul>
-        {% for bugid in bugids -%}
-        <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
-        {% endfor -%}
-      </ul>
-    </p>
-    <p>Sincerely,<br>
-      Release Management Bot
-    </p>
-    <p>
-      See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
-    </p>
-  </body>
-</html>
+<p>The following bugs have Version set but not status_firefox:
+  <ul>
+    {% for bugid in bugids -%}
+    <li><a href="https://bugzilla.mozilla.org/{{ bugid }}">{{ bugid }}</a></li>
+    {% endfor -%}
+  </ul>
+</p>


### PR DESCRIPTION
The goal is to be able to gather different messages from different tools when nagging people (to avoid to much emails).