### PR TITLE
Improve no-assignee tool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ requests>=2.20.0
 simplejson==2.3.3
 wsgiref==0.1.2
 pexpect==3.1
+python-Levenshtein>=0.12.0


### PR DESCRIPTION
* the strategy is to get commenters in the bug when we don't have any patch (phab, ...) and try to match commenter and hg patchers.
* when we've several potential assignee then get the one who have the max of comments
* use jaro-winkler similarity to try to find similarity in emails between hg people and bz people