### PR TITLE
Update requirements for libmozdata (0.1.49)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ certifi>=2017.4.17
 chardet<3.1.0,>=3.0.2
 httplib2>=0.9.1
 humanize>=0.5.1
-libmozdata>=0.1.47
+libmozdata>=0.1.49
 path.py==2.2.2
 pep8==0.6.1
 pyflakes==0.5.0


### PR DESCRIPTION
Libmozdata 0.1.49 fixed a bug when getting invalid dates for release_owners stuff.