### PR TITLE
Autofix component

### DIFF
--- a/auto_nag/scripts/component.py
+++ b/auto_nag/scripts/component.py
@@ -11,6 +11,7 @@ class Component(BugbugScript):
     def __init__(self):
         super(Component, self).__init__()
         self.model = ComponentModel.load(self.retrieve_model('component'))
+        self.autofix_component = {}
 
     def description(self):
         return 'Assign a component to untriaged bugs'
@@ -68,18 +69,38 @@ class Component(BugbugScript):
 
         result = {}
         for bug, prob, index, component in zip(bugs, probs, indexes, components):
-            # Only return result for which we are sure enough.
-            if prob[index] >= utils.get_config(self.name(), 'confidence_threshold'):
-                bug_id = str(bug['id'])
-                result[bug_id] = {
-                    'id': bug_id,
-                    'summary': self.get_summary(bug),
-                    'component': component,
-                    'confidence': int(round(100 * prob[index])),
-                }
+            # Only return results for which we are sure enough.
+            if prob[index] < self.get_config('confidence_threshold'):
+                continue
+
+            bug_id = str(bug['id'])
+            result[bug_id] = {
+                'id': bug_id,
+                'summary': self.get_summary(bug),
+                'component': component,
+                'confidence': int(round(100 * prob[index])),
+            }
+
+            if prob[index] >= self.get_config('autofix_confidence_threshold'):
+                # If we were able to predict both product and component, assign both product and component.
+                # Otherwise, just change the product.
+                if '::' in component:
+                    self.autofix_component[bug_id] = {
+                        'product': component[:component.index('::')],
+                        'component': component[component.index('::') + 2:],
+                    }
+                elif bug['product'] != component:
+                    self.autofix_component[bug_id] = {
+                        'product': component,
+                    }
 
         return result
 
+    def has_individual_autofix(self):
+        return True
+
+    def get_autofix_change(self):
+        return self.autofix_component
 
 if __name__ == '__main__':
     Component().run()

--- a/auto_nag/scripts/component.py
+++ b/auto_nag/scripts/component.py
@@ -100,7 +100,8 @@ class Component(BugbugScript):
         return True
 
     def get_autofix_change(self):
-        return self.autofix_component
+        cc = {'cc': {'add': self.get_config('cc')}}
+        return {bug_id: (data.update(cc) or data) for bug_id, data in self.autofix_component.items()}
 
 if __name__ == '__main__':
     Component().run()

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -373,6 +373,7 @@
     "component":
     {
         "confidence_threshold": 0.6,
+        "autofix_confidence_threshold": 0.6,
         "receivers":
         [
             "calixte@mozilla.com",

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -380,6 +380,12 @@
             "ehumphries@mozilla.com",
             "sylvestre@mozilla.com",
             "mcastelluccio@mozilla.com"
+        ],
+        "cc":
+        [
+            "sledru@mozilla.com",
+            "mcastelluccio@mozilla.com",
+            "cdenizet@mozilla.com"
         ]
     }
 }


### PR DESCRIPTION
Example output:
```
The bug: 1530408 will be autofixed with:
{'product': 'WebExtensions', 'cc': {'add': ['sledru@mozilla.com', 'mcastelluccio@mozilla.com', 'cdenizet@mozilla.com']}}
The bug: 1530647 will be autofixed with:
{'product': 'Toolkit', 'component': 'Password Manager', 'cc': {'add': ['sledru@mozilla.com', 'mcastelluccio@mozilla.com', 'cdenizet@mozilla.com']}}
```