### PR TITLE
Send all component suggestions in the email report (only apply confidence threshold for the autofix)

### DIFF
--- a/auto_nag/scripts/component.py
+++ b/auto_nag/scripts/component.py
@@ -68,10 +68,6 @@ class Component(BugbugScript):
 
         result = {}
         for bug, prob, index, component in zip(bugs, probs, indexes, components):
-            # Only return results for which we are sure enough.
-            if prob[index] < self.get_config('confidence_threshold'):
-                continue
-
             bug_id = str(bug['id'])
             result[bug_id] = {
                 'id': bug_id,
@@ -80,7 +76,7 @@ class Component(BugbugScript):
                 'confidence': int(round(100 * prob[index])),
             }
 
-            if prob[index] >= self.get_config('autofix_confidence_threshold'):
+            if prob[index] >= self.get_config('confidence_threshold'):
                 # If we were able to predict both product and component, assign both product and component.
                 # Otherwise, just change the product (if it's not one of the base ones).
                 if '::' in component:

--- a/auto_nag/scripts/component.py
+++ b/auto_nag/scripts/component.py
@@ -68,6 +68,10 @@ class Component(BugbugScript):
 
         result = {}
         for bug, prob, index, component in zip(bugs, probs, indexes, components):
+            # Skip product-only suggestions that are not useful.
+            if '::' not in component and (bug['product'] == component or component in ['Core', 'Firefox', 'Toolkit']):
+                continue
+
             bug_id = str(bug['id'])
             result[bug_id] = {
                 'id': bug_id,
@@ -78,13 +82,13 @@ class Component(BugbugScript):
 
             if prob[index] >= self.get_config('confidence_threshold'):
                 # If we were able to predict both product and component, assign both product and component.
-                # Otherwise, just change the product (if it's not one of the base ones).
+                # Otherwise, just change the product.
                 if '::' in component:
                     self.autofix_component[bug_id] = {
                         'product': component[:component.index('::')],
                         'component': component[component.index('::') + 2:],
                     }
-                elif bug['product'] != component and component not in ['Core', 'Firefox', 'Toolkit']:
+                else:
                     self.autofix_component[bug_id] = {
                         'product': component,
                     }

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -389,7 +389,6 @@
     "component":
     {
         "confidence_threshold": 0.6,
-        "autofix_confidence_threshold": 0.6,
         "receivers":
         [
             "calixte@mozilla.com",


### PR DESCRIPTION
And also skip unuseful suggestions in the email report, not only in the autofix.