### PR TITLE
Use bugbug from PyPI

### DIFF
--- a/check_bugbug_version.py
+++ b/check_bugbug_version.py
@@ -7,8 +7,8 @@ import requests
 
 def get_bugbug_version(requirements):
     for line in requirements.splitlines():
-        if line.startswith('https://github.com/marco-c/bugbug/archive/'):
-            return line[len('https://github.com/marco-c/bugbug/archive/'):line.index('.tar')]
+        if line.startswith('bugbug=='):
+            return line[len('bugbug=='):]
 
     return None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ pexpect==3.1
 python-Levenshtein>=0.12.0
 pytz>=2018.9
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.0.0/en_core_web_sm-2.0.0.tar.gz#egg=en-core-web-sm
-https://github.com/marco-c/bugbug/archive/909894c1cb0eb421c79200d94289b98c973a7dd4.tar.gz#egg=bugbug
+bugbug==0.0.2


### PR DESCRIPTION
This will avoid the periodic problem we have where you need to uninstall and reinstall bugbug after an update because of pip's poor support for package URLs.