### PR TITLE
Apply component suggestion to max 100 bugs at a time

### DIFF
--- a/auto_nag/scripts/component.py
+++ b/auto_nag/scripts/component.py
@@ -48,6 +48,7 @@ class Component(BugbugScript):
             # Ignore bugs for which somebody has ever modified the product or the component.
             'n1': 1, 'f1': 'product', 'o1': 'changedafter', 'v1': '1970-01-01',
             'n2': 1, 'f2': 'component', 'o2': 'changedafter', 'v2': '1970-01-01',
+            'limit': 100, 'order': 'bug_id desc',
         }
 
         return params


### PR DESCRIPTION
I've noticed we have > 21000 untriaged bugs, so it's better to do the automatic triage a bit at a time.
When we'll have a smaller backlog, we can remove the limit.

Question: should we ignore resolved bugs? Or maybe only INVALID bugs? If yes, @calixteman can you add this to the query yourself (or I can do it on Monday).