### PR TITLE
Automatically triage ASSIGNED and REOPENED bugs too

### DIFF
--- a/auto_nag/scripts/component.py
+++ b/auto_nag/scripts/component.py
@@ -48,9 +48,7 @@ class Component(BugbugScript):
             # Ignore bugs for which somebody has ever modified the product or the component.
             'n1': 1, 'f1': 'product', 'o1': 'changedafter', 'v1': '1970-01-01',
             'n2': 1, 'f2': 'component', 'o2': 'changedafter', 'v2': '1970-01-01',
-            'f3': 'bug_status',
-            'o3': 'anyexact',
-            'v3': 'UNCONFIRMED,NEW,ASSIGNED,REOPENED',
+            'bug_status': '__open__',
         }
 
         return params

--- a/auto_nag/scripts/component.py
+++ b/auto_nag/scripts/component.py
@@ -50,7 +50,7 @@ class Component(BugbugScript):
             'n2': 1, 'f2': 'component', 'o2': 'changedafter', 'v2': '1970-01-01',
             'f3': 'bug_status',
             'o3': 'anyexact',
-            'v3': 'UNCONFIRMED,NEW',
+            'v3': 'UNCONFIRMED,NEW,ASSIGNED,REOPENED',
         }
 
         return params


### PR DESCRIPTION
For ASSIGNED there is less value as a developer has definitely already seen it and so it was likely already triaged.
For REOPENED, it might be more valuable.