### PR TITLE
Don't retrieve bugs which are definitely not regressions

### DIFF
--- a/auto_nag/scripts/regression.py
+++ b/auto_nag/scripts/regression.py
@@ -41,8 +41,8 @@ class Regression(BugbugScript):
 
         params = {
             'f1': 'keywords',
-            'o1': 'notsubstring',
-            'v1': 'regression',
+            'o1': 'nowords',
+            'v1': 'regression,feature,meta',
             'f2': 'longdesc',
             'o2': 'anywordssubstr',
             'v2': 'regress caus',


### PR DESCRIPTION
We download them, but then we definitely won't mark them as regressions, so we might as well just avoid downloading them altogether.