### PR TITLE
Disable has_str_no_hasstr for the moment

### DIFF
--- a/runauto_nag_hourly.sh
+++ b/runauto_nag_hourly.sh
@@ -29,7 +29,7 @@ python -m auto_nag.scripts.leave_open
 
 # has a STR without flag has_str
 # common
-python -m auto_nag.scripts.has_str_no_hasstr
+# python -m auto_nag.scripts.has_str_no_hasstr
 
 # hasRegressionRange is set but no regression keyword
 # common


### PR DESCRIPTION
This tool is probably too stupid.
We should try to improve the detection of a true str to avoid stupid things like this:
STR:
  I'm not a STR