### PR TITLE
Call retrieve_model only once in BugbugScript's constructor

### DIFF
--- a/auto_nag/bugbug_utils.py
+++ b/auto_nag/bugbug_utils.py
@@ -18,6 +18,7 @@ from auto_nag.bzcleaner import BzCleaner
 class BugbugScript(BzCleaner):
     def __init__(self):
         super().__init__()
+        self.model = self.model_class.load(self.retrieve_model())
 
     def retrieve_model(self):
         os.makedirs('models', exist_ok=True)

--- a/auto_nag/scripts/component.py
+++ b/auto_nag/scripts/component.py
@@ -9,8 +9,8 @@ from bugbug.models.component import ComponentModel
 
 class Component(BugbugScript):
     def __init__(self):
+        self.model_class = ComponentModel
         super().__init__()
-        self.model = ComponentModel.load(self.retrieve_model())
         self.autofix_component = {}
         self.frequency = 'daily'
 

--- a/auto_nag/scripts/defectenhancementtask.py
+++ b/auto_nag/scripts/defectenhancementtask.py
@@ -8,8 +8,8 @@ from bugbug.models.defect_enhancement_task import DefectEnhancementTaskModel
 
 class DefectEnhancementTask(BugbugScript):
     def __init__(self):
+        self.model_class = DefectEnhancementTaskModel
         super().__init__()
-        self.model = DefectEnhancementTaskModel.load(self.retrieve_model())
         self.autofix_type = {}
 
     def description(self):

--- a/auto_nag/scripts/regression.py
+++ b/auto_nag/scripts/regression.py
@@ -8,8 +8,8 @@ from bugbug.models.regression import RegressionModel
 
 class Regression(BugbugScript):
     def __init__(self):
+        self.model_class = RegressionModel
         super().__init__()
-        self.model = RegressionModel.load(self.retrieve_model())
         self.autofix_regression = []
 
     def description(self):


### PR DESCRIPTION
A very small refactoring to avoid duplicating some code.