### PR TITLE
Make defectenhancementtask script apply autofix more often

### DIFF
--- a/auto_nag/scripts/component.py
+++ b/auto_nag/scripts/component.py
@@ -4,6 +4,7 @@
 
 from auto_nag import logger
 from auto_nag.bugbug_utils import BugbugScript
+from auto_nag.utils import nice_round
 from bugbug.models.component import ComponentModel
 
 
@@ -113,7 +114,7 @@ class Component(BugbugScript):
                 'id': bug_id,
                 'summary': self.get_summary(bug),
                 'component': suggestion,
-                'confidence': int(round(100 * prob[index])),
+                'confidence': nice_round(prob[index]),
                 'autofixed': False,
             }
 

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -507,7 +507,7 @@
             "intermittent-bug-filer@mozilla.bugs",
             "wptsync@mozilla.bugs"
         ],
-        "confidence_threshold": 0.95,
+        "confidence_threshold": 0.9,
         "cc":
         [
             "sledru@mozilla.com",

--- a/auto_nag/scripts/defectenhancementtask.py
+++ b/auto_nag/scripts/defectenhancementtask.py
@@ -3,6 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from auto_nag.bugbug_utils import BugbugScript
+from auto_nag.utils import nice_round
 from bugbug.models.defect_enhancement_task import DefectEnhancementTaskModel
 
 
@@ -84,9 +85,6 @@ class DefectEnhancementTask(BugbugScript):
             defect_prob = prob[labels_map['defect']]
             enhancement_prob = prob[labels_map['enhancement']]
             task_prob = prob[labels_map['task']]
-
-            def nice_round(val):
-                return int(round(100 * val))
 
             results[bug['id']] = {
                 'id': bug['id'],

--- a/auto_nag/scripts/regression.py
+++ b/auto_nag/scripts/regression.py
@@ -3,6 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from auto_nag.bugbug_utils import BugbugScript
+from auto_nag.utils import nice_round
 from bugbug.models.regression import RegressionModel
 
 
@@ -72,7 +73,7 @@ class Regression(BugbugScript):
             result[bug_id] = {
                 'id': bug_id,
                 'summary': self.get_summary(bug),
-                'confidence': int(round(100 * prob[1])),
+                'confidence': nice_round(prob[1]),
                 'autofixed': False,
             }
 

--- a/auto_nag/utils.py
+++ b/auto_nag/utils.py
@@ -519,3 +519,6 @@ def get_nightly_version_from_bz():
     Bugzilla(bugids=['1234567'], bughandler=bug_handler, bugdata=data).get_data().wait()
 
     return max(data)
+
+def nice_round(val):
+    return int(round(100 * val))

--- a/auto_nag/utils.py
+++ b/auto_nag/utils.py
@@ -520,5 +520,6 @@ def get_nightly_version_from_bz():
 
     return max(data)
 
+
 def nice_round(val):
     return int(round(100 * val))

--- a/templates/defectenhancementtask.html
+++ b/templates/defectenhancementtask.html
@@ -6,7 +6,7 @@
       </tr>
     </thead>
     <tbody>
-      {% for i, (bugid, summary, type, bugbug_type, confidence, autofixed) in enumerate(data) -%}
+      {% for i, (bugid, summary, type, bugbug_type, confidence, confidences, autofixed) in enumerate(data) -%}
       <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
         <td>
           <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
@@ -21,7 +21,7 @@
           {{ bugbug_type }}
         </td>
         <td {% if autofixed %}bgcolor="#00FF00"{% endif -%}>
-          {{ confidence }}
+          {{ confidences }}
         </td>
       </tr>
       {% endfor -%}


### PR DESCRIPTION
This does a few things:
1) Decrease minimum confidence threshold for the autofixer to 90%;
2) When the script is not sure between task and enhancement, but it is sure it is not a defect, apply the autofix (previously it was only applying when it was sure about task vs enhancement, but even most humans are not sure about those...).

The classifier got better with the additional data we have collected over the past few weeks (since people started to set the bug type).