### PR TITLE
to_triage: add jdescottes

### DIFF
--- a/auto_nag/round_robin.py
+++ b/auto_nag/round_robin.py
@@ -63,6 +63,16 @@ class RoundRobin(object):
     def get_components(self):
         return list(self.data.keys())
 
+    def get_fallback(self, bug):
+        pc = bug['product'] + '::' + bug['component']
+        if pc not in self.data:
+            mail = bug.get('triage_owner')
+        else:
+            cal = self.data[pc]
+            mail = cal.get_fallback_bzmail()
+
+        return self.people.get_moz_mail(mail)
+
     def get_nick(self, bzmail):
         if bzmail not in self.nicks:
 

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -565,7 +565,7 @@
             {
                 "[0;+∞[":
                 {
-                    "supervisor": "n+1",
+                    "supervisor": "fallback",
                     "days": ["Mon", "Tue", "Wed", "Thu", "Fri"]
                 }
             }
@@ -573,6 +573,10 @@
         "teams":
         [
             "DOM:Workers & Storage"
+        ],
+        "persons":
+        [
+            "jdescottes@mozilla.com"
         ]
     }
 }

--- a/auto_nag/utils.py
+++ b/auto_nag/utils.py
@@ -498,7 +498,9 @@ def get_products_components(data):
     for pc in data:
         if '::' in pc:
             p, c = pc.split('::', 1)
-            prods.add(c)
+            prods.add(p)
+        else:
+            c = pc
         comps.add(c)
     return prods, comps
 


### PR DESCRIPTION
We had no way to just send an email to triage_owners who want to receive a reminder for priorities.
So this patch just add the ability for an owner without round robin to be nagged.