### PR TITLE
Add a regressor.py script that finds risky recently landed patches

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = Levenshtein,alembic,bugbug,dateutil,filelock,humanize,icalendar,icalevents,jinja2,libmozdata,numpy,pytz,requests,six,sqlalchemy,whatthepatch
+known_third_party = Levenshtein,alembic,bugbug,dateutil,filelock,hglib,humanize,icalendar,icalevents,jinja2,libmozdata,numpy,pytz,requests,six,sqlalchemy,whatthepatch

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -601,5 +601,21 @@
             "mcastelluccio@mozilla.com",
             "cdenizet@mozilla.com"
         ]
+    },
+    "regressor":
+    {
+        "max_days_in_cache": 7,
+        "receivers":
+        [
+            "calixte@mozilla.com",
+            "sylvestre@mozilla.com",
+            "mcastelluccio@mozilla.com"
+        ],
+        "cc":
+        [
+            "sledru@mozilla.com",
+            "mcastelluccio@mozilla.com",
+            "cdenizet@mozilla.com"
+        ]
     }
 }

--- a/auto_nag/scripts/regressor.py
+++ b/auto_nag/scripts/regressor.py
@@ -1,0 +1,99 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+
+import hglib
+from bugbug import db, repository
+from bugbug.models.regressor import RegressorModel
+
+from auto_nag import logger
+from auto_nag.bugbug_utils import BugbugScript
+from auto_nag.utils import get_login_info, nice_round
+
+
+class Regressor(BugbugScript):
+    def __init__(self):
+        self.model_class = RegressorModel
+
+        self.repo_dir = get_login_info()["repo_dir"]
+
+        if not os.path.exists(self.repo_dir):
+            cmd = hglib.util.cmdbuilder(
+                "robustcheckout",
+                "https://hg.mozilla.org/mozilla-central",
+                self.repo_dir,
+                purge=True,
+                sharebase=self.repo_dir + "-shared",
+                networkattempts=7,
+                branch=b"tip",
+            )
+
+            cmd.insert(0, hglib.HGPATH)
+
+            proc = hglib.util.popen(cmd)
+            out, err = proc.communicate()
+            if proc.returncode:
+                raise hglib.error.CommandError(cmd, proc.returncode, out, err)
+
+            logger.info("mozilla-central cloned")
+
+            # Remove pushlog DB to make sure it's regenerated.
+            try:
+                os.remove(os.path.join(self.repo_dir, ".hg", "pushlog2.db"))
+            except FileNotFoundError:
+                logger.info("pushlog database doesn't exist")
+
+        logger.info("Pulling and updating mozilla-central")
+        with hglib.open(self.repo_dir) as hg:
+            hg.pull(update=True)
+        logger.info("mozilla-central pulled and updated")
+
+        db.download_version(repository.COMMITS_DB)
+        if db.is_old_version(repository.COMMITS_DB) or not os.path.exists(
+            repository.COMMITS_DB
+        ):
+            db.download(repository.COMMITS_DB, force=True, support_files_too=True)
+
+        super().__init__()
+
+    def description(self):
+        return "[Using ML] Recently landed risky patches"
+
+    def columns(self):
+        return ["id", "summary", "result", "confidence"]
+
+    def sort_columns(self):
+        return lambda p: -p[3]
+
+    def get_bugs(self, date="today", bug_ids=[]):
+        self.query_url = ""
+
+        # Ignore already analyzed commits.
+        for commit in repository.get_commits():
+            pass
+
+        rev_start = f"children({commit['node']})"
+
+        commits = repository.download_commits(self.repo_dir, rev_start, ret=True)
+
+        commits = [commit for commit in commits if not commit["ever_backedout"]]
+
+        probs = self.model.classify(commits, True)
+        indexes = probs.argmax(axis=-1)
+
+        result = {}
+        for commit, prob, index in zip(commits, probs, indexes):
+            result[commit["node"]] = {
+                "id": commit["node"],
+                "summary": commit["desc"].split("\n", 1)[0],
+                "result": "Risky" if prob[1] > 0.5 else "Not risky",
+                "confidence": nice_round(prob[index]),
+            }
+
+        return result
+
+
+if __name__ == "__main__":
+    Regressor().run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ icalendar==4.0.3
 sqlalchemy==1.3.4
 filelock==3.0.12
 alembic==1.0.10
+python-hglib==2.6.1

--- a/runauto_nag_daily.sh
+++ b/runauto_nag_daily.sh
@@ -117,4 +117,7 @@ python -m auto_nag.log --send
 # Try to detect potential missing Has STR using bugbug
 python -m auto_nag.scripts.stepstoreproduce
 
+# Evaluate riskiness of recently landed patches
+python -m auto_nag.scripts.regressor
+
 deactivate

--- a/templates/regressor.html
+++ b/templates/regressor.html
@@ -1,0 +1,27 @@
+<p>The following {{ plural('commit is', data, pword='commits are') }} risky / not risky:
+  <table {{ table_attrs }}>
+    <thead>
+      <tr>
+        <th>Commit</th><th>Description</th><th>Risky?</th><th>Confidence</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for i, (node, desc, result, confidence) in enumerate(data) -%}
+      <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+        <td>
+          <a href="https://hg.mozilla.org/mozilla-central/rev/{{ node }}">{{ node }}</a>
+        </td>
+        <td>
+          {{ desc | e }}
+        </td>
+        <td>
+          {{ result }}
+        </td>
+        <td>
+          {{ confidence }}
+        </td>
+      </tr>
+      {% endfor -%}
+    </tbody>
+  </table>
+</p>


### PR DESCRIPTION
Depends on https://github.com/mozilla/bugbug/pull/546.

Instead of using Phabricator, I'm simply classifying recently landed commits.
In the future, this will be removed from autonag and put on Taskcluster integrating it with eventlistener, where we already have all the infra in place.