### PR TITLE
Fix default Python version declaration in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,5 @@ repos:
     hooks:
     -   id: check-hooks-apply
     -   id: check-useless-excludes
-python_version: python3.6
+default_language_version:
+    python: python3.7


### PR DESCRIPTION
See also https://github.com/mozilla/bugbug/pull/584.