### PR TITLE
Nag main triage owner in case where a bugzilla email on phonebook or in the calendar is invalid

### DIFF
--- a/auto_nag/erroneous_bzmail.py
+++ b/auto_nag/erroneous_bzmail.py
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from . import mail, utils
+from .round_robin import RoundRobin
+
+
+def send_mail(err, dryrun=False):
+    for fb, bzmails in err.items():
+        mail.send_from_template(
+            "erroneous_bzmail_email.html",
+            fb,
+            "Triage owners with erroneous Bugzilla email",
+            Cc=utils.get_config("common", "receivers"),
+            dryrun=dryrun,
+            bzmails=bzmails,
+            plural=utils.plural,
+        )
+
+
+def check_erroneous_bzmail(dryrun=False):
+    rr = RoundRobin.get_instance()
+    err = rr.get_erroneous_bzmail()
+    if err:
+        send_mail(err, dryrun=dryrun)

--- a/auto_nag/multinaggers.py
+++ b/auto_nag/multinaggers.py
@@ -20,6 +20,7 @@ class MultiNaggers(object):
             assert isinstance(arg, Nag), "{} is not a Nag".format(type(arg))
             assert isinstance(arg, BzCleaner), "{} is not a BZCleaner".format(type(arg))
         self.naggers = list(args)
+        self.is_dryrun = True
 
     def description(self):
         return ""
@@ -51,13 +52,14 @@ class MultiNaggers(object):
 
     def run(self):
         args = self.get_args_parser().parse_args()
+        self.is_dryrun = args.dryrun
         self.date = lmdutils.get_date_ymd(args.date)
         for nagger in self.naggers:
             nagger.send_nag_mail = False
             nagger.run()
-        self.gather(args.dryrun)
+        self.gather()
 
-    def gather(self, dryrun):
+    def gather(self):
         env = Environment(loader=FileSystemLoader("templates"))
         common = env.get_template("common.html")
         login_info = utils.get_login_info()
@@ -87,6 +89,6 @@ class MultiNaggers(object):
                 Cc=list(sorted(Cc)),
                 html=True,
                 login=login_info,
-                dryrun=dryrun,
+                dryrun=self.is_dryrun,
             )
             time.sleep(1)

--- a/auto_nag/nag_me.py
+++ b/auto_nag/nag_me.py
@@ -14,7 +14,7 @@ from auto_nag.people import People
 class Nag(object):
     def __init__(self):
         super(Nag, self).__init__()
-        self.people = People()
+        self.people = People.get_instance()
         self.send_nag_mail = True
         self.data = {}
         self.nag_date = None

--- a/auto_nag/people.py
+++ b/auto_nag/people.py
@@ -29,6 +29,9 @@ IM_NICK = re.compile(r"([\w\.@]+)")
 
 
 class People:
+
+    _instance = None
+
     def __init__(self, p=None):
         if p is None:
             with open("./auto_nag/scripts/configs/people.json", "r") as In:
@@ -48,6 +51,12 @@ class People:
         self.names = {}
         self._amend()
         self.matrix = None
+
+    @staticmethod
+    def get_instance():
+        if People._instance is None:
+            People._instance = People()
+        return People._instance
 
     def _get_name_parts(self, name):
         """Get names from name"""

--- a/auto_nag/round_robin.py
+++ b/auto_nag/round_robin.py
@@ -15,13 +15,29 @@ from auto_nag.round_robin_calendar import Calendar
 
 
 class RoundRobin(object):
+
+    _instances = {}
+
     def __init__(self, rr=None, people=None, teams=None):
-        self.people = People() if people is None else people
+        self.people = People.get_instance() if people is None else people
         self.components_by_triager = {}
         self.all_calendars = []
         self.feed(teams, rr=rr)
         self.nicks = {}
+        self.erroneous_bzmail = {}
         utils.init_random()
+
+    @staticmethod
+    def get_instance(teams=None):
+        if teams is None:
+            if None not in RoundRobin._instances:
+                RoundRobin._instances[None] = RoundRobin()
+            return RoundRobin._instances[None]
+
+        teams = tuple(teams)
+        if teams not in RoundRobin._instances:
+            RoundRobin._instances[teams] = RoundRobin(teams=teams)
+        return RoundRobin._instances[teams]
 
     def get_calendar(self, team, data):
         fallback = data["fallback"]
@@ -87,13 +103,28 @@ class RoundRobin(object):
 
         return self.people.get_moz_mail(mail)
 
-    def get_nick(self, bzmail):
+    def get_erroneous_bzmail(self):
+        return self.erroneous_bzmail
+
+    def add_erroneous_bzmail(self, bzmail, prod_comp, cal):
+        logger.error(f"No nick for {bzmail} for {prod_comp}")
+        fb = cal.get_fallback_mozmail()
+        if fb not in self.erroneous_bzmail:
+            self.erroneous_bzmail[fb] = {bzmail}
+        else:
+            self.erroneous_bzmail[fb].add(bzmail)
+
+    def get_nick(self, bzmail, prod_comp, cal):
         if bzmail not in self.nicks:
 
             def handler(user):
                 self.nicks[bzmail] = user["nick"]
 
             BugzillaUser(user_names=[bzmail], user_handler=handler).wait()
+
+        if bzmail not in self.nicks:
+            self.add_erroneous_bzmail(bzmail, prod_comp, cal)
+            return None
 
         return self.nicks[bzmail]
 
@@ -118,7 +149,7 @@ class RoundRobin(object):
         persons = cal.get_persons(date)
         fb = cal.get_fallback_bzmail()
         if not persons or all(p is None for _, p in persons):
-            return fb, self.get_nick(fb)
+            return fb, self.get_nick(fb, pc, cal)
 
         bzmails = []
         for _, p in persons:
@@ -129,12 +160,12 @@ class RoundRobin(object):
         if only_one:
             bzmail = bzmails[randint(0, len(bzmails) - 1)]
             if has_nick:
-                nick = self.get_nick(bzmail)
+                nick = self.get_nick(bzmail, pc, cal)
                 return bzmail, nick
             return bzmail
 
         if has_nick:
-            return [(bzmail, self.get_nick(bzmail)) for bzmail in bzmails]
+            return [(bzmail, self.get_nick(bzmail, pc, cal)) for bzmail in bzmails]
         return bzmails
 
     def get_who_to_nag(self, date):

--- a/auto_nag/round_robin_calendar.py
+++ b/auto_nag/round_robin_calendar.py
@@ -31,7 +31,7 @@ class Calendar(object):
     def __init__(self, cal, fallback, team_name, people=None):
         super(Calendar, self).__init__()
         self.cal = cal
-        self.people = People() if people is None else people
+        self.people = People.get_instance() if people is None else people
         self.fallback = fallback
         self.fb_bzmail = self.people.get_bzmail_from_name(self.fallback)
         self.fb_mozmail = self.people.get_moz_mail(self.fb_bzmail)

--- a/auto_nag/round_robin_fallback.py
+++ b/auto_nag/round_robin_fallback.py
@@ -22,11 +22,10 @@ def send_mail(nag, dryrun=False):
 
 
 def check_people(date, dryrun=False):
-    rr = RoundRobin()
+    rr = RoundRobin.get_instance()
     # nag is a dict: persons -> list of persons
     #                team -> team name
     nag = rr.get_who_to_nag(date)
-    print(nag)
     send_mail(nag, dryrun=dryrun)
 
 

--- a/auto_nag/scripts/assignee_no_login.py
+++ b/auto_nag/scripts/assignee_no_login.py
@@ -15,7 +15,7 @@ class AssigneeNoLogin(BzCleaner):
         self.nmonths = utils.get_config(self.name(), "number_of_months", 12)
         self.autofix_assignee = {}
         self.default_assignees = utils.get_default_assignees()
-        self.people = people.People()
+        self.people = people.People.get_instance()
 
     def description(self):
         return "Open and assigned bugs where the assignee's last login was more than {} months ago".format(

--- a/auto_nag/scripts/code_freeze_week.py
+++ b/auto_nag/scripts/code_freeze_week.py
@@ -28,7 +28,7 @@ class CodeFreezeWeek(BzCleaner):
         if not self.init_versions():
             return
 
-        self.people = People()
+        self.people = People.get_instance()
         self.nightly = self.versions["central"]
         self.beta = self.versions["beta"]
         self.release = self.versions["release"]

--- a/auto_nag/scripts/has_str_no_range.py
+++ b/auto_nag/scripts/has_str_no_range.py
@@ -11,7 +11,7 @@ from auto_nag.people import People
 class HasSTRNoRange(BzCleaner):
     def __init__(self):
         super(HasSTRNoRange, self).__init__()
-        self.people = People()
+        self.people = People.get_instance()
         self.autofix_reporters = {}
 
     def description(self):

--- a/auto_nag/scripts/leave_open_no_activity.py
+++ b/auto_nag/scripts/leave_open_no_activity.py
@@ -10,7 +10,7 @@ from auto_nag.people import People
 class LeaveOpenNoActivity(BzCleaner):
     def __init__(self):
         super(LeaveOpenNoActivity, self).__init__()
-        self.people = People()
+        self.people = People.get_instance()
         self.nmonths = utils.get_config(self.name(), "months_lookup")
         self.max_ni = utils.get_config(self.name(), "max_ni")
         self.skiplist = set(utils.get_config(self.name(), "skiplist", []))

--- a/auto_nag/scripts/meta_no_deps_no_activity.py
+++ b/auto_nag/scripts/meta_no_deps_no_activity.py
@@ -10,7 +10,7 @@ from auto_nag.people import People
 class MetaNoDepsNoActivity(BzCleaner):
     def __init__(self):
         super(MetaNoDepsNoActivity, self).__init__()
-        self.people = People()
+        self.people = People.get_instance()
         self.nmonths = utils.get_config(self.name(), "months_lookup")
         self.max_ni = utils.get_config(self.name(), "max_ni")
         self.skiplist = set(utils.get_config(self.name(), "skiplist", []))

--- a/auto_nag/scripts/newbie_with_ni.py
+++ b/auto_nag/scripts/newbie_with_ni.py
@@ -12,7 +12,7 @@ from auto_nag.people import People
 class NewbieWithNI(BzCleaner):
     def __init__(self):
         super(NewbieWithNI, self).__init__()
-        self.people = People()
+        self.people = People.get_instance()
         self.ndays = utils.get_config(self.name(), "number_of_days", 14)
         self.ncomments = utils.get_config(self.name(), "number_of_comments", 2)
         self.autofix_reporters = {}

--- a/auto_nag/scripts/to_triage.py
+++ b/auto_nag/scripts/to_triage.py
@@ -15,9 +15,7 @@ class ToTriage(BzCleaner, Nag):
     def __init__(self):
         super(ToTriage, self).__init__()
         self.escalation = Escalation(self.people, data=self.get_config("escalation"))
-        self.round_robin = RoundRobin(
-            people=self.people, teams=self.get_config("teams", [])
-        )
+        self.round_robin = RoundRobin.get_instance(teams=self.get_config("teams", []))
         self.components = self.round_robin.get_components()
         for person in self.get_config("persons", []):
             self.components += utils.get_triage_owners()[person]

--- a/auto_nag/scripts/workflow/multi_nag.py
+++ b/auto_nag/scripts/workflow/multi_nag.py
@@ -17,7 +17,7 @@ class WorkflowMultiNag(MultiNaggers):
     def __init__(self):
         super(WorkflowMultiNag, self).__init__(
             NoPriority("first"),
-            # NoPriority("second"),
+            NoPriority("second"),
             # P1NoActivity(),
             # P1NoAssignee(),
             # P2NoActivity(),

--- a/auto_nag/scripts/workflow/multi_nag.py
+++ b/auto_nag/scripts/workflow/multi_nag.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from auto_nag.erroneous_bzmail import check_erroneous_bzmail
 from auto_nag.multinaggers import MultiNaggers
 
 from .no_priority import NoPriority
@@ -16,7 +17,7 @@ class WorkflowMultiNag(MultiNaggers):
     def __init__(self):
         super(WorkflowMultiNag, self).__init__(
             NoPriority("first"),
-            NoPriority("second"),
+            # NoPriority("second"),
             # P1NoActivity(),
             # P1NoAssignee(),
             # P2NoActivity(),
@@ -31,4 +32,6 @@ class WorkflowMultiNag(MultiNaggers):
 
 if __name__ == "__main__":
     # P2MergeDay().run()
-    WorkflowMultiNag().run()
+    wmn = WorkflowMultiNag()
+    wmn.run()
+    check_erroneous_bzmail(dryrun=wmn.is_dryrun)

--- a/auto_nag/scripts/workflow/no_priority.py
+++ b/auto_nag/scripts/workflow/no_priority.py
@@ -23,7 +23,7 @@ class NoPriority(BzCleaner, Nag):
             data=utils.get_config(self.name(), "escalation-{}".format(typ)),
             skiplist=utils.get_config("workflow", "supervisor_skiplist", []),
         )
-        self.round_robin = RoundRobin(people=self.people)
+        self.round_robin = RoundRobin.get_instance()
         self.components_skiplist = utils.get_config("workflow", "components_skiplist")
 
     def description(self):

--- a/auto_nag/tests/test_round_robin.py
+++ b/auto_nag/tests/test_round_robin.py
@@ -66,7 +66,7 @@ class TestRoundRobin(unittest.TestCase):
         }
 
     @staticmethod
-    def _get_nick(x, bzmail):
+    def _get_nick(x, bzmail, pc, cal):
         return bzmail.split("@")[0]
 
     def test_get(self):

--- a/templates/erroneous_bzmail_email.html
+++ b/templates/erroneous_bzmail_email.html
@@ -1,0 +1,6 @@
+<p>The following {{ plural('email needs', bzmails, pword='emails need') }} to be updated in phonebook and/or in the calendar because {{ plural('it isn\'t', bzmails, pword='they aren\'t') }} valid in Bugzilla:</p>
+<ul>
+  {% for bzmail in bzmails -%}
+  <li>{{ bzmail }}</li>
+  {% endfor -%}
+</ul>


### PR DESCRIPTION
There's an issue with the Hiroyuki Ikezoe's bugmail which is incorrect in either phonebook or in calendar.
So the goal of this tool is to send an email to the main triage owner to inform her/him of the issue.
To avoid to send several emails and since the data (people.py or round_robin_calendar.py) are constant across the same run, this patch make them singleton.