### PR TITLE
Update scripts to use new bugbug HTTP answer

### DIFF
--- a/auto_nag/scripts/component.py
+++ b/auto_nag/scripts/component.py
@@ -82,7 +82,7 @@ class Component(BugbugScript):
             bug = bug_data["bug"]
             prob = bug_data["prob"]
             index = bug_data["index"]
-            suggestion = bug_data["suggestion"]
+            suggestion = bug_data["class"]
             conflated_components_mapping = bug_data["extra_data"][
                 "conflated_components_mapping"
             ]

--- a/auto_nag/scripts/defectenhancementtask.py
+++ b/auto_nag/scripts/defectenhancementtask.py
@@ -90,7 +90,7 @@ class DefectEnhancementTask(BugbugScript):
             bug = bug_data["bug"]
             prob = bug_data["prob"]
             index = bug_data["index"]
-            suggestion = bug_data["suggestion"]
+            suggestion = bug_data["class"]
             labels_map = bug_data["extra_data"]["labels_map"]
 
             assert suggestion in {


### PR DESCRIPTION
Following https://github.com/mozilla/bugbug/pull/670, the classification field
was renamed into class, update the needed scripts.

Wait until https://tools.taskcluster.net/groups/RCUA7UVDSVmZVoiQM948QQ/tasks/B6SiGklhSBOR9hbq_7fxQQ/details has finished before merging this PR.