### PR TITLE
Disable defect/enhancement/task autofix until we can detect if users chose the type

### DIFF
--- a/auto_nag/scripts/defectenhancementtask.py
+++ b/auto_nag/scripts/defectenhancementtask.py
@@ -129,11 +129,12 @@ class DefectEnhancementTask(BzCleaner):
 
             # Only autofix results for which we are sure enough.
             # And only autofix defect -> task/enhancement for now, unless we're 100% sure.
-            if prob[index] == 1.0 or (
+            """if prob[index] == 1.0 or (
                 bug["type"] == "defect"
                 and (enhancement_prob + task_prob)
                 >= self.get_config("confidence_threshold")
-            ):
+            ):"""
+            if prob[index] == 1.0:
                 results[bug_id]["autofixed"] = True
                 self.autofix_type[bug["id"]] = suggestion
 


### PR DESCRIPTION
There are still quite a bit of mistakes, but I think it's better not to override decisions when they are made with cognition.
So, let's disable the autofix (unless we are 100% sure) until https://bugzilla.mozilla.org/show_bug.cgi?id=1565403 is fixed.