### PR TITLE
no_crashes: remove the reporter_exception

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -164,7 +164,6 @@
         "number_of_weeks": 12,
         "reporter_exception":
         [
-            "intermittent-bug-filer@mozilla.bugs"
         ],
         "keyword_exception":
         [


### PR DESCRIPTION
It was introduced in PR #376 but not sure why.
It would close crashes like:
https://bugzilla.mozilla.org/show_bug.cgi?id=1599058