### PR TITLE
Fix not_landed tool: it was broken because we dl too big attachments in bugzilla

### DIFF
--- a/auto_nag/scripts/not_landed.py
+++ b/auto_nag/scripts/not_landed.py
@@ -171,10 +171,13 @@ class NotLanded(BzCleaner):
         nightly_pat = Bugzilla.get_landing_patterns(channels=["nightly"])[0][0]
 
         def comment_handler(bug, bugid, data):
-            # if the last comment contains a backout: don't nag
-            last = bug["comments"][-1]["text"].lower()
-            if nightly_pat.match(last) and ("backed out" in last or "backout" in last):
-                data[bugid]["backout"] = True
+            # if a comment contains a backout: don't nag
+            for comment in bug["comments"]:
+                comment = comment["text"].lower()
+                if nightly_pat.match(comment) and (
+                    "backed out" in comment or "backout" in comment
+                ):
+                    data[bugid]["backout"] = True
 
         def attachment_id_handler(attachments, bugid, data):
             for a in attachments:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Jinja2==2.11.1
 argparse==1.4.0
 humanize>=0.5.1
-libmozdata>=0.1.60
+libmozdata>=0.1.65
 pep8==1.7.1
 pyflakes==2.1.1
 python-dateutil>=2.5.2


### PR DESCRIPTION
We got all the attachments in a bug to and filter them according their content-type.
But in some bugs there are several attachments with video, pictures, ...
So the idea is to not retrieve attachment data but just get the ids of the ones with a correct content-type and in a second time just dl the data.
It requires: https://github.com/mozilla/libmozdata/pull/177