### PR TITLE
[uplift_beta] Check for Phabricator's attachment

### DIFF
--- a/auto_nag/scripts/uplift_beta.py
+++ b/auto_nag/scripts/uplift_beta.py
@@ -117,6 +117,10 @@ class UpliftBeta(BzCleaner):
             "o7": "casesubstring",
             # this a part of the comment we've in templates/uplift_beta_needinfo.txt
             "v7": ", is this bug important enough to require an uplift?",
+            # Check if have at least one attachment which is a Phabricator request
+            "f8": "attachments.mimetype",
+            "o8": "anywordssubstr",
+            "v8": "text/x-phabricator-request",
         }
 
         return params


### PR DESCRIPTION
Should remove a part of the noise.
If we still have noise, we can go deeper in the attachments to check if the associated Phab requests are published using Phab api.