### PR TITLE
Update survey_sec_bugs.html

### DIFF
--- a/templates/survey_sec_bugs.html
+++ b/templates/survey_sec_bugs.html
@@ -1,5 +1,5 @@
 
-<p>Here are security bugs closed in the last month where we asked for feedback about creating static analysis:
+<p>Here are security bugs where we asked for feedback about creating static analysis:
     <table {{ table_attrs }}>
       <thead>
         <tr>


### PR DESCRIPTION
This removes the time specification in report e-mail.

With this change and the existing behavior of setting a whiteboard tag being a survey is request is added, I think we can comfortably increase the frequency of this rule.

@calixteman, can you change the cronjbo to run this weekly? We'll ideally increase to every 48hrs in the future. I'll follow up with another pull request that adds more possible survey recipients.