### PR TITLE
Make regression script only change the regression keyword when it's really sure

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -141,7 +141,7 @@
             "intermittent-bug-filer@mozilla.bugs",
             "wptsync@mozilla.bugs"
         ],
-        "confidence_threshold": 0.9,
+        "confidence_threshold": 1.0,
         "cc":
         [
         ]


### PR DESCRIPTION
Until I have time to figure out the wrong classifications.