### PR TITLE
Search spam bugs and bugs without steps to reproduce only between bugs filed by people without editbugs

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -592,11 +592,6 @@
             "mcastelluccio@mozilla.com"
         ],
         "days_lookup": 3,
-        "reporter_skiplist":
-        [
-            "intermittent-bug-filer@mozilla.bugs",
-            "wptsync@mozilla.bugs"
-        ],
         "confidence_threshold": 0.9,
         "cc":
         [

--- a/auto_nag/scripts/spambug.py
+++ b/auto_nag/scripts/spambug.py
@@ -37,14 +37,11 @@ class SpamBug(BzCleaner):
             # Ignore closed bugs.
             "bug_status": "__open__",
             "f1": "reporter",
-            "v1": "@mozilla",
+            "v1": "%group.editbugs%",
             "o1": "notsubstring",
-            "f2": "reporter",
-            "v2": "@softvision",
-            "o2": "notsubstring",
-            "f3": "creation_ts",
-            "o3": "greaterthan",
-            "v3": start_date,
+            "f2": "creation_ts",
+            "o2": "greaterthan",
+            "v2": start_date,
         }
 
     def get_bugs(self, date="today", bug_ids=[]):

--- a/auto_nag/scripts/stepstoreproduce.py
+++ b/auto_nag/scripts/stepstoreproduce.py
@@ -23,9 +23,6 @@ class StepsToReproduce(BzCleaner):
     def get_bz_params(self, date):
         start_date, end_date = self.get_dates(date)
 
-        reporter_skiplist = self.get_config("reporter_skiplist", default=[])
-        reporter_skiplist = ",".join(reporter_skiplist)
-
         params = {
             "include_fields": ["id", "groups", "summary"],
             "bug_type": "defect",
@@ -36,8 +33,8 @@ class StepsToReproduce(BzCleaner):
             "o2": "changedbefore",
             "v2": end_date,
             "f3": "reporter",
-            "o3": "nowords",
-            "v3": reporter_skiplist,
+            "o3": "notsubstring",
+            "v3": "%group.editbugs%",
             "f4": "cf_has_str",
             "o4": "equals",
             "v4": "---",


### PR DESCRIPTION
We can assume bugs filed by people with `editbugs` are good enough, as they are expert enough bug filers.