### PR TITLE
Add regression_set_status_flags tool

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -647,5 +647,11 @@
             "mcastelluccio@mozilla.com",
             "jcristau@mozilla.com"
         ]
+    },
+    "regression_set_status_flags": {
+        "receivers":
+        [
+            "jcristau@mozilla.com"
+        ]
     }
 }

--- a/auto_nag/scripts/regression_set_status_flags.py
+++ b/auto_nag/scripts/regression_set_status_flags.py
@@ -1,4 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from libmozdata.bugzilla import Bugzilla
+
 from auto_nag import utils
 from auto_nag.bzcleaner import BzCleaner
 

--- a/auto_nag/scripts/regression_set_status_flags.py
+++ b/auto_nag/scripts/regression_set_status_flags.py
@@ -1,0 +1,106 @@
+
+from libmozdata.bugzilla import Bugzilla
+from auto_nag import utils
+from auto_nag.bzcleaner import BzCleaner
+
+
+class RegressionSetStatusFlags(BzCleaner):
+    def __init__(self):
+        super().__init__()
+        self.init_versions()
+        self.status_central = utils.get_flag(self.versions['central'], 'status', 'central')
+        self.status_beta = utils.get_flag(self.versions['beta'], 'status', 'beta')
+        self.status_release = utils.get_flag(self.versions['release'], 'status', 'release')
+        self.status_changes = {}
+
+    def description(self):
+        return "Set release status flags based on info from the regressing bug"
+
+    def get_bz_params(self, date):
+        # XXX should perhaps look further back than one week, e.g. a month?
+        start_date, _ = self.get_dates(date)
+        fields = [
+            'regressed_by',
+            self.status_central,
+            self.status_beta,
+            self.status_release,
+        ]
+
+        return {
+            'include_fields': fields,
+            'f1': 'creation_ts',
+            'o1': 'greaterthan',
+            'v1': start_date,
+            'f2': 'regressed_by',
+            'o2': 'isnotempty',
+            'f3': 'cf_status_firefox_release',
+            'o3': 'nowords',
+            'v3': 'fixed,verified',
+            'f4': 'cf_status_firefox_beta',
+            'o4': 'equals',
+            'v4': '---',
+            'resolution': ['---', 'FIXED'],
+        }
+
+    def handle_bug(self, bug, data):
+        bugid = bug['id']
+        if len(bug['regressed_by']) != 1:
+            # either we don't have access to the regressor, or there's more than one, either way leave things alone
+            return
+        bug['regressed_by'] = bug['regressed_by'][0]
+        data[str(bugid)] = bug
+
+    def get_flags_from_regressing_bugs(self, bugs):
+        def bug_handler(bug, data):
+            data[bug['id']] = bug
+
+        bugids = {info['regressed_by'] for info in bugs.values()}
+        if not bugids:
+            return {}
+        data = {}
+        filtered_bugs = {}
+        Bugzilla(bugids=list(bugids), bughandler=bug_handler, bugdata=data).get_data().wait()
+
+        for bugid, info in bugs.items():
+            regressor = info['regressed_by']
+            assert regressor in data
+            regression_versions = sorted(v for v in data[regressor] if v.startswith('cf_status_firefox') and data[regressor][v] in ('fixed', 'verified'))
+            if not regression_versions:
+                 # don't know what to do, ignore
+                 continue
+            if regression_versions[0].startswith('cf_status_firefox_esr'):
+                 continue
+            regressed_version = int(regression_versions[0][len('cf_status_firefox'):])
+            if regressed_version < int(self.versions['release']):
+                # old regression, leave it alone
+                continue
+            self.status_changes[bugid] = {}
+            for channel in ('release', 'beta', 'central'):
+                v = int(self.versions[channel])
+                info[channel] = info['cf_status_firefox%d' % v]
+                if info['cf_status_firefox%d' % v] != '---':
+                    # XXX maybe check for consistency?
+                    continue
+                if v < regressed_version:
+                    self.status_changes[bugid]['cf_status_firefox%d' % v] = 'unaffected'
+                    info[channel] = 'unaffected'
+                else:
+                    self.status_changes[bugid]['cf_status_firefox%d' % v] = 'affected'
+                    info[channel] = 'affected'
+                filtered_bugs[bugid] = info
+
+        return filtered_bugs
+
+    def get_bugs(self, *args, **kwargs):
+        bugs = super().get_bugs(*args, **kwargs)
+        bugs = self.get_flags_from_regressing_bugs(bugs)
+        return bugs
+
+    def get_autofix_change(self):
+        return self.status_changes
+
+    def columns(self):
+        return ('id', 'summary', 'regressed_by', 'central', 'beta', 'release')
+
+if __name__ == '__main__':
+    RegressionSetStatusFlags().run()

--- a/auto_nag/scripts/regression_set_status_flags.py
+++ b/auto_nag/scripts/regression_set_status_flags.py
@@ -1,4 +1,3 @@
-
 from libmozdata.bugzilla import Bugzilla
 from auto_nag import utils
 from auto_nag.bzcleaner import BzCleaner
@@ -8,9 +7,13 @@ class RegressionSetStatusFlags(BzCleaner):
     def __init__(self):
         super().__init__()
         self.init_versions()
-        self.status_central = utils.get_flag(self.versions['central'], 'status', 'central')
-        self.status_beta = utils.get_flag(self.versions['beta'], 'status', 'beta')
-        self.status_release = utils.get_flag(self.versions['release'], 'status', 'release')
+        self.status_central = utils.get_flag(
+            self.versions["central"], "status", "central"
+        )
+        self.status_beta = utils.get_flag(self.versions["beta"], "status", "beta")
+        self.status_release = utils.get_flag(
+            self.versions["release"], "status", "release"
+        )
         self.status_changes = {}
 
     def description(self):
@@ -20,73 +23,80 @@ class RegressionSetStatusFlags(BzCleaner):
         # XXX should perhaps look further back than one week, e.g. a month?
         start_date, _ = self.get_dates(date)
         fields = [
-            'regressed_by',
+            "regressed_by",
             self.status_central,
             self.status_beta,
             self.status_release,
         ]
 
         return {
-            'include_fields': fields,
-            'f1': 'creation_ts',
-            'o1': 'greaterthan',
-            'v1': start_date,
-            'f2': 'regressed_by',
-            'o2': 'isnotempty',
-            'f3': 'cf_status_firefox_release',
-            'o3': 'nowords',
-            'v3': 'fixed,verified',
-            'f4': 'cf_status_firefox_beta',
-            'o4': 'equals',
-            'v4': '---',
-            'resolution': ['---', 'FIXED'],
+            "include_fields": fields,
+            "f1": "creation_ts",
+            "o1": "greaterthan",
+            "v1": start_date,
+            "f2": "regressed_by",
+            "o2": "isnotempty",
+            "f3": "cf_status_firefox_release",
+            "o3": "nowords",
+            "v3": "fixed,verified",
+            "f4": "cf_status_firefox_beta",
+            "o4": "equals",
+            "v4": "---",
+            "resolution": ["---", "FIXED"],
         }
 
     def handle_bug(self, bug, data):
-        bugid = bug['id']
-        if len(bug['regressed_by']) != 1:
+        bugid = bug["id"]
+        if len(bug["regressed_by"]) != 1:
             # either we don't have access to the regressor, or there's more than one, either way leave things alone
             return
-        bug['regressed_by'] = bug['regressed_by'][0]
+        bug["regressed_by"] = bug["regressed_by"][0]
         data[str(bugid)] = bug
 
     def get_flags_from_regressing_bugs(self, bugs):
         def bug_handler(bug, data):
-            data[bug['id']] = bug
+            data[bug["id"]] = bug
 
-        bugids = {info['regressed_by'] for info in bugs.values()}
+        bugids = {info["regressed_by"] for info in bugs.values()}
         if not bugids:
             return {}
         data = {}
         filtered_bugs = {}
-        Bugzilla(bugids=list(bugids), bughandler=bug_handler, bugdata=data).get_data().wait()
+        Bugzilla(
+            bugids=list(bugids), bughandler=bug_handler, bugdata=data
+        ).get_data().wait()
 
         for bugid, info in bugs.items():
-            regressor = info['regressed_by']
+            regressor = info["regressed_by"]
             assert regressor in data
-            regression_versions = sorted(v for v in data[regressor] if v.startswith('cf_status_firefox') and data[regressor][v] in ('fixed', 'verified'))
+            regression_versions = sorted(
+                v
+                for v in data[regressor]
+                if v.startswith("cf_status_firefox")
+                and data[regressor][v] in ("fixed", "verified")
+            )
             if not regression_versions:
-                 # don't know what to do, ignore
-                 continue
-            if regression_versions[0].startswith('cf_status_firefox_esr'):
-                 continue
-            regressed_version = int(regression_versions[0][len('cf_status_firefox'):])
-            if regressed_version < int(self.versions['release']):
+                # don't know what to do, ignore
+                continue
+            if regression_versions[0].startswith("cf_status_firefox_esr"):
+                continue
+            regressed_version = int(regression_versions[0][len("cf_status_firefox") :])
+            if regressed_version < int(self.versions["release"]):
                 # old regression, leave it alone
                 continue
             self.status_changes[bugid] = {}
-            for channel in ('release', 'beta', 'central'):
+            for channel in ("release", "beta", "central"):
                 v = int(self.versions[channel])
-                info[channel] = info['cf_status_firefox%d' % v]
-                if info['cf_status_firefox%d' % v] != '---':
+                info[channel] = info["cf_status_firefox%d" % v]
+                if info["cf_status_firefox%d" % v] != "---":
                     # XXX maybe check for consistency?
                     continue
                 if v < regressed_version:
-                    self.status_changes[bugid]['cf_status_firefox%d' % v] = 'unaffected'
-                    info[channel] = 'unaffected'
+                    self.status_changes[bugid]["cf_status_firefox%d" % v] = "unaffected"
+                    info[channel] = "unaffected"
                 else:
-                    self.status_changes[bugid]['cf_status_firefox%d' % v] = 'affected'
-                    info[channel] = 'affected'
+                    self.status_changes[bugid]["cf_status_firefox%d" % v] = "affected"
+                    info[channel] = "affected"
                 filtered_bugs[bugid] = info
 
         return filtered_bugs
@@ -100,7 +110,8 @@ class RegressionSetStatusFlags(BzCleaner):
         return self.status_changes
 
     def columns(self):
-        return ('id', 'summary', 'regressed_by', 'central', 'beta', 'release')
+        return ("id", "summary", "regressed_by", "central", "beta", "release")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     RegressionSetStatusFlags().run()

--- a/auto_nag/scripts/regression_set_status_flags.py
+++ b/auto_nag/scripts/regression_set_status_flags.py
@@ -104,6 +104,12 @@ class RegressionSetStatusFlags(BzCleaner):
                     info[channel] = "affected"
                 filtered_bugs[bugid] = info
 
+        for bugid in filtered_bugs:
+            self.status_changes[bugid]["comment"] = {
+                "body": "Updating status flags based on regressing bug %d" % (
+                    bugs[bugid]["regressed_by"]
+                )
+            }
         return filtered_bugs
 
     def get_bugs(self, *args, **kwargs):

--- a/auto_nag/scripts/regression_set_status_flags.py
+++ b/auto_nag/scripts/regression_set_status_flags.py
@@ -92,23 +92,21 @@ class RegressionSetStatusFlags(BzCleaner):
             self.status_changes[bugid] = {}
             for channel in ("release", "beta", "central"):
                 v = int(self.versions[channel])
-                info[channel] = info["cf_status_firefox%d" % v]
-                if info["cf_status_firefox%d" % v] != "---":
+                info[channel] = info[f"cf_status_firefox{v}"]
+                if info[f"cf_status_firefox{v}"] != "---":
                     # XXX maybe check for consistency?
                     continue
                 if v < regressed_version:
-                    self.status_changes[bugid]["cf_status_firefox%d" % v] = "unaffected"
+                    self.status_changes[bugid][f"cf_status_firefox{v}"] = "unaffected"
                     info[channel] = "unaffected"
                 else:
-                    self.status_changes[bugid]["cf_status_firefox%d" % v] = "affected"
+                    self.status_changes[bugid][f"cf_status_firefox{v}"] = "affected"
                     info[channel] = "affected"
                 filtered_bugs[bugid] = info
 
         for bugid in filtered_bugs:
             self.status_changes[bugid]["comment"] = {
-                "body": "Updating status flags based on regressing bug %d" % (
-                    bugs[bugid]["regressed_by"]
-                )
+                "body": f'{self.description()} {bugs[bugid]["regressed_by"]}'
             }
         return filtered_bugs
 

--- a/auto_nag/tests/test_regression_set_status_flags.py
+++ b/auto_nag/tests/test_regression_set_status_flags.py
@@ -1,0 +1,80 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+import unittest
+
+from auto_nag import utils
+from auto_nag.bzcleaner import BzCleaner
+from auto_nag.scripts.regression_set_status_flags import RegressionSetStatusFlags
+
+
+def mock_get_checked_versions():
+    return {
+        "release": 2,
+        "beta": 3,
+        "nightly": 4,
+        "central": 4,
+    }
+
+
+def mock_get_bugs(self, *args, **kwargs):
+    return {
+        "1111": {
+            "id": 100,
+            "cf_status_firefox2": "---",
+            "cf_status_firefox3": "affected",
+            "cf_status_firefox4": "fixed",
+            "regressed_by": 111,
+        },
+        "2222": {
+            "id": 2222,
+            "cf_status_firefox2": "---",
+            "cf_status_firefox3": "---",
+            "cf_status_firefox4": "---",
+            "regressed_by": 222,
+        },
+    }
+
+
+def mock_get_flags_from_regressing_bugs(self, bugids):
+    assert sorted(bugids) == [111, 222]
+    return {
+        111: {
+            "id": 111,
+            "cf_status_firefox_esr4": "fixed",
+            "cf_status_firefox3": "fixed",
+        },
+        222: {"id": 222, "cf_status_firefox1": "fixed",},
+    }
+
+
+class TestSetStatusFlags(unittest.TestCase):
+    def setUp(self):
+        self.orig_get_checked_versions = utils.get_checked_versions
+        self.orig_get_bugs = BzCleaner.get_bugs
+        self.orig_get_flags_from_regressing_bugs = (
+            RegressionSetStatusFlags.get_flags_from_regressing_bugs
+        )
+        utils.get_checked_versions = mock_get_checked_versions
+        BzCleaner.get_bugs = mock_get_bugs
+        RegressionSetStatusFlags.get_flags_from_regressing_bugs = (
+            mock_get_flags_from_regressing_bugs
+        )
+
+    def tearDown(self):
+        utils.get_checked_versions = self.orig_get_checked_versions
+        BzCleaner.get_bugs = self.orig_get_bugs
+        RegressionSetStatusFlags.get_flags_from_regressing_bugs = (
+            self.orig_get_flags_from_regressing_bugs
+        )
+
+    def test_status_changes(self):
+        r = RegressionSetStatusFlags()
+        bugs = r.get_bugs()
+        # 2222 is left unchanged because it regressed too long ago
+        self.assertEqual(sorted(bugs), ["1111"])
+        self.assertEqual(list(r.status_changes), ["1111"])
+        self.assertEqual(
+            sorted(r.status_changes["1111"]), ["cf_status_firefox2", "comment"]
+        )
+        self.assertEqual(r.status_changes["1111"]["cf_status_firefox2"], "unaffected")

--- a/runauto_nag_daily.sh
+++ b/runauto_nag_daily.sh
@@ -112,6 +112,9 @@ python -m auto_nag.scripts.defectenhancementtask
 # Try to detect potential missing Has STR using bugbug
 python -m auto_nag.scripts.stepstoreproduce
 
+# Update status flags for regressions based on their regressor
+python -m auto_nag.scripts.regression_set_status_flags -d
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m auto_nag.log --send

--- a/runauto_nag_daily.sh
+++ b/runauto_nag_daily.sh
@@ -113,7 +113,7 @@ python -m auto_nag.scripts.defectenhancementtask
 python -m auto_nag.scripts.stepstoreproduce
 
 # Update status flags for regressions based on their regressor
-python -m auto_nag.scripts.regression_set_status_flags -d
+python -m auto_nag.scripts.regression_set_status_flags
 
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND

--- a/templates/regression_set_status_flags.html
+++ b/templates/regression_set_status_flags.html
@@ -1,0 +1,26 @@
+<p>The following regressions had their status flags updated:
+<table {{ table_attrs }}>
+<thead>
+<tr>
+<th>Bug</th>
+<th>Summary</th>
+<th>Regressed by</th>
+<th>Status in central</th>
+<th>Status in beta</th>
+<th>Status in release</th>
+</tr>
+</thead>
+<tbody>
+{% for i, (bug, summary, regressor, central, beta, release) in enumerate(data) %}
+<tr>
+<td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bug }}">{{ bug }}</a></td>
+<td>{{ summary }}</td>
+<td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ regressor }}">{{ regressor }}</a></td>
+<td>{{ central }}</td>
+<td>{{ beta }}</td>
+<td>{{ release }}</td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+</p>


### PR DESCRIPTION
Look for recently filed regressions whose regressed_by field is not
empty.  If the regressing bug landed in the current release or later,
set the new bug's status flags for central/beta/release accordingly, if
they were previously unset.

Fixes #882