### PR TITLE
Only send email with bugs classified as spam

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -579,7 +579,7 @@
             "sylvestre@mozilla.com"
         ],
         "days_lookup": 3,
-        "confidence_threshold": 0.8,
+        "confidence_threshold": 0.9,
         "cc":[]
     },
     "stepstoreproduce":

--- a/auto_nag/scripts/spambug.py
+++ b/auto_nag/scripts/spambug.py
@@ -17,7 +17,7 @@ class SpamBug(BzCleaner):
         return "[Using ML] Detect spam bugs"
 
     def columns(self):
-        return ["id", "summary", "confidence", "autofixed"]
+        return ["id", "summary", "confidence"]
 
     def sort_columns(self):
         return lambda p: (-p[2], -int(p[0]))
@@ -73,11 +73,13 @@ class SpamBug(BzCleaner):
             bug = raw_bugs[bug_id]
             prob = bug_data["prob"]
 
+            if prob[1] < self.get_config("confidence_threshold"):
+                continue
+
             results[bug_id] = {
                 "id": bug_id,
                 "summary": bug["summary"],
                 "confidence": nice_round(prob[1]),
-                "autofixed": prob[1] > self.get_config("confidence_threshold"),
             }
 
         return results

--- a/templates/spambug.html
+++ b/templates/spambug.html
@@ -6,7 +6,7 @@
         </tr>
       </thead>
       <tbody>
-        {% for i, (bugid, summary, confidence, autofixed) in enumerate(data) -%}
+        {% for i, (bugid, summary, confidence) in enumerate(data) -%}
         <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
           <td>
             <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
@@ -14,7 +14,7 @@
           <td>
             {{ summary | e }}
           </td>
-          <td {% if autofixed %}bgcolor="#00FF00"{% endif -%}>
+          <td>
             {{ confidence }}
           </td>
         </tr>


### PR DESCRIPTION
So far we were sending an email with *all* results: both bugs classified as spam and bugs not classified as spam.
I've checked the results for a few weeks, and most of the bugs with low confidence are indeed not spam, so I think it's time to only notify of possibly spam bugs.