### PR TITLE
Don't move Firefox::General bugs to Core::Internationalization

### DIFF
--- a/auto_nag/scripts/component.py
+++ b/auto_nag/scripts/component.py
@@ -129,6 +129,15 @@ class Component(BzCleaner):
             }:
                 continue
 
+            # Don't move bugs from Firefox::General to Core::Internationalization.
+            if (
+                bug["product"] == "Firefox"
+                and bug["component"] == "General"
+                and suggested_product == "Core"
+                and suggested_component == "Internationalization"
+            ):
+                continue
+
             bug_id = str(bug["id"])
 
             result = {


### PR DESCRIPTION
Bugbug wrongly learned that the bugs mentioning Fluent should go in Core::Internationalization
because over the past few months all bugs mentioning Fluent are in that component (while
Fluent was being built and starting to be used).
Now that Fluent is ready, bugs to track migrations are no longer filed in that component, but are
filed in the component of the migration.
See https://github.com/mozilla/bugbug/issues/1484.