### PR TITLE
[sec survey] Check for 'open' whiteboard tag only

### DIFF
--- a/auto_nag/scripts/survey_sec_bugs.py
+++ b/auto_nag/scripts/survey_sec_bugs.py
@@ -36,7 +36,7 @@ class SurveySecurityBugs(BzCleaner):
             # whiteboard does not have [sec-survey] (to avoid us asking twice)
             "f2": "status_whiteboard",
             "o2": "notsubstring",
-            "v2": "[sec-survey]",
+            "v2": "[sec-survey",
             # has at least one attachment (i.e., hopefully a patch)
             "f3": "attachments.count",
             "o3": "greaterthan",


### PR DESCRIPTION
Background: Some mozillians want to to change the whiteboard tag into [sec-survey+] when they have responded to the survey.
To allow for this, we will query for `[sec-survey` instead of `[sec-survey]` (note the missing closing bracket), when looking for bugs in which we need to query