### PR TITLE
Stop soft freeze emails going out after the merge

### DIFF
--- a/auto_nag/scripts/code_freeze_week.py
+++ b/auto_nag/scripts/code_freeze_week.py
@@ -55,10 +55,10 @@ class CodeFreezeWeek(BzCleaner):
 
     def must_run(self, date):
         for c in get_calendar():
-            # if freeze is the 2019-03-11, then the tool must run the day after
-            # until 2019-03-2018 (a week after)
+            # run from the soft freeze date until merge day
             freeze = c["soft freeze"]
-            if freeze <= date <= freeze + relativedelta(days=6):
+            merge = c["merge"]
+            if freeze <= date < merge:
                 return True
         return False
 


### PR DESCRIPTION
Back in the day the soft freeze lasted a week, but that hasn't been true
for a while now.  Use merge day as the end date instead of hardcoding a
duration.