### PR TITLE
Update layout team round robin config

### DIFF
--- a/auto_nag/scripts/configs/layout_round_robin.json
+++ b/auto_nag/scripts/configs/layout_round_robin.json
@@ -31,6 +31,7 @@
     "animation":
     {
 <<<<<<< HEAD
+<<<<<<< HEAD
         "calendar": "https://triage.layout.team/animation.json"
     },
     "style-system":
@@ -104,74 +105,80 @@
 }
 =======
         "calendar": "https://gecko.layout.team/triage/animation.json"
+=======
+        "calendar": "https://triage.layout.team/animation.json"
+>>>>>>> Update layout triage calendar URLs
     },
     "style-system":
     {
-        "calendar": "https://gecko.layout.team/triage/style-system.json"
+        "calendar": "https://triage.layout.team/style-system.json"
     },
     "layout-general":
     {
-        "calendar": "https://gecko.layout.team/triage/layout-general.json"
+        "calendar": "https://triage.layout.team/layout-general.json"
     },
     "layout-block-inline":
     {
-        "calendar": "https://gecko.layout.team/triage/layout-block-inline.json"
+        "calendar": "https://triage.layout.team/layout-block-inline.json"
     },
     "layout-columns":
     {
-        "calendar": "https://gecko.layout.team/triage/layout-columns.json"
+        "calendar": "https://triage.layout.team/layout-columns.json"
     },
     "layout-flex":
     {
-        "calendar": "https://gecko.layout.team/triage/layout-flex.json"
+        "calendar": "https://triage.layout.team/layout-flex.json"
     },
     "layout-floats":
     {
-        "calendar": "https://gecko.layout.team/triage/layout-floats.json"
+        "calendar": "https://triage.layout.team/layout-floats.json"
     },
     "layout-form-controls":
     {
-        "calendar": "https://gecko.layout.team/triage/layout-form-controls.json"
+        "calendar": "https://triage.layout.team/layout-form-controls.json"
     },
     "layout-generated":
     {
-        "calendar": "https://gecko.layout.team/triage/layout-generated.json"
+        "calendar": "https://triage.layout.team/layout-generated.json"
     },
     "layout-grid":
     {
-        "calendar": "https://gecko.layout.team/triage/layout-grid.json"
+        "calendar": "https://triage.layout.team/layout-grid.json"
     },
     "layout-replaced":
     {
-        "calendar": "https://gecko.layout.team/triage/layout-replaced.json"
+        "calendar": "https://triage.layout.team/layout-replaced.json"
     },
     "layout-positioned":
     {
-        "calendar": "https://gecko.layout.team/triage/layout-positioned.json"
+        "calendar": "https://triage.layout.team/layout-positioned.json"
     },
     "layout-ruby":
     {
-        "calendar": "https://gecko.layout.team/triage/layout-ruby.json"
+        "calendar": "https://triage.layout.team/layout-ruby.json"
     },
     "layout-overflow":
     {
-        "calendar": "https://gecko.layout.team/triage/layout-overflow.json"
+        "calendar": "https://triage.layout.team/layout-overflow.json"
     },
     "layout-tables":
     {
-        "calendar": "https://gecko.layout.team/triage/layout-tables.json"
+        "calendar": "https://triage.layout.team/layout-tables.json"
     },
     "layout-text":
     {
-        "calendar": "https://gecko.layout.team/triage/layout-text.json"
+        "calendar": "https://triage.layout.team/layout-text.json"
     },
     "printing":
     {
-        "calendar": "https://gecko.layout.team/triage/printing.json"
+        "calendar": "https://triage.layout.team/printing.json"
     },
     "svg":
     {
-        "calendar": "https://gecko.layout.team/triage/svg.json"
+        "calendar": "https://triage.layout.team/svg.json"
     }
 }
+<<<<<<< HEAD
 >>>>>>> Add round robin config for layout team
+=======
+>>>>>>> Update layout triage calendar URLs

--- a/auto_nag/scripts/configs/layout_round_robin.json
+++ b/auto_nag/scripts/configs/layout_round_robin.json
@@ -1,16 +1,8 @@
 {
-    "fallback": "Sean Voisen",
+    "fallback": "Cameron McCormack",
     "components":
     {
-<<<<<<< HEAD
-<<<<<<< HEAD
         "Core::CSS Transitions and Animations": "animation",
-=======
-        "Core::CSS Animations and Transitions": "animation",
->>>>>>> Add round robin config for layout team
-=======
-        "Core::CSS Transitions and Animations": "animation",
->>>>>>> Update layout triage calendar URLs
         "Core::CSS Parsing and Computation": "style-system",
         "Core::DOM: CSS Object Model": "style-system",
         "Core::Layout": "layout-general",
@@ -34,161 +26,74 @@
     },
     "animation":
     {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> Update layout triage calendar URLs
-        "calendar": "https://triage.layout.team/animation.json"
+        "calendar": "https://mozilla.github.io/layout-triage/animation.json"
     },
     "style-system":
     {
-        "calendar": "https://triage.layout.team/style-system.json"
+        "calendar": "https://mozilla.github.io/layout-triage/style-system.json"
     },
     "layout-general":
     {
-        "calendar": "https://triage.layout.team/layout-general.json"
+        "calendar": "https://mozilla.github.io/layout-triage/layout-general.json"
     },
     "layout-block-inline":
     {
-        "calendar": "https://triage.layout.team/layout-block-inline.json"
+        "calendar": "https://mozilla.github.io/layout-triage/layout-block-inline.json"
     },
     "layout-columns":
     {
-        "calendar": "https://triage.layout.team/layout-columns.json"
+        "calendar": "https://mozilla.github.io/layout-triage/layout-columns.json"
     },
     "layout-flex":
     {
-        "calendar": "https://triage.layout.team/layout-flex.json"
+        "calendar": "https://mozilla.github.io/layout-triage/layout-flex.json"
     },
     "layout-floats":
     {
-        "calendar": "https://triage.layout.team/layout-floats.json"
+        "calendar": "https://mozilla.github.io/layout-triage/layout-floats.json"
     },
     "layout-form-controls":
     {
-        "calendar": "https://triage.layout.team/layout-form-controls.json"
+        "calendar": "https://mozilla.github.io/layout-triage/layout-form-controls.json"
     },
     "layout-generated":
     {
-        "calendar": "https://triage.layout.team/layout-generated.json"
+        "calendar": "https://mozilla.github.io/layout-triage/layout-generated.json"
     },
     "layout-grid":
     {
-        "calendar": "https://triage.layout.team/layout-grid.json"
+        "calendar": "https://mozilla.github.io/layout-triage/layout-grid.json"
     },
     "layout-replaced":
     {
-        "calendar": "https://triage.layout.team/layout-replaced.json"
+        "calendar": "https://mozilla.github.io/layout-triage/layout-replaced.json"
     },
     "layout-positioned":
     {
-        "calendar": "https://triage.layout.team/layout-positioned.json"
+        "calendar": "https://mozilla.github.io/layout-triage/layout-positioned.json"
     },
     "layout-ruby":
     {
-        "calendar": "https://triage.layout.team/layout-ruby.json"
+        "calendar": "https://mozilla.github.io/layout-triage/layout-ruby.json"
     },
     "layout-overflow":
     {
-        "calendar": "https://triage.layout.team/layout-overflow.json"
+        "calendar": "https://mozilla.github.io/layout-triage/layout-overflow.json"
     },
     "layout-tables":
     {
-        "calendar": "https://triage.layout.team/layout-tables.json"
+        "calendar": "https://mozilla.github.io/layout-triage/layout-tables.json"
     },
     "layout-text":
     {
-        "calendar": "https://triage.layout.team/layout-text.json"
+        "calendar": "https://mozilla.github.io/layout-triage/layout-text.json"
     },
     "printing":
     {
-        "calendar": "https://triage.layout.team/printing.json"
+        "calendar": "https://mozilla.github.io/layout-triage/printing.json"
     },
     "svg":
     {
-        "calendar": "https://triage.layout.team/svg.json"
-<<<<<<< HEAD
+        "calendar": "https://mozilla.github.io/layout-triage/svg.json"
     }
 }
-=======
-        "calendar": "https://gecko.layout.team/triage/animation.json"
-=======
-        "calendar": "https://triage.layout.team/animation.json"
->>>>>>> Update layout triage calendar URLs
-    },
-    "style-system":
-    {
-        "calendar": "https://triage.layout.team/style-system.json"
-    },
-    "layout-general":
-    {
-        "calendar": "https://triage.layout.team/layout-general.json"
-    },
-    "layout-block-inline":
-    {
-        "calendar": "https://triage.layout.team/layout-block-inline.json"
-    },
-    "layout-columns":
-    {
-        "calendar": "https://triage.layout.team/layout-columns.json"
-    },
-    "layout-flex":
-    {
-        "calendar": "https://triage.layout.team/layout-flex.json"
-    },
-    "layout-floats":
-    {
-        "calendar": "https://triage.layout.team/layout-floats.json"
-    },
-    "layout-form-controls":
-    {
-        "calendar": "https://triage.layout.team/layout-form-controls.json"
-    },
-    "layout-generated":
-    {
-        "calendar": "https://triage.layout.team/layout-generated.json"
-    },
-    "layout-grid":
-    {
-        "calendar": "https://triage.layout.team/layout-grid.json"
-    },
-    "layout-replaced":
-    {
-        "calendar": "https://triage.layout.team/layout-replaced.json"
-    },
-    "layout-positioned":
-    {
-        "calendar": "https://triage.layout.team/layout-positioned.json"
-    },
-    "layout-ruby":
-    {
-        "calendar": "https://triage.layout.team/layout-ruby.json"
-    },
-    "layout-overflow":
-    {
-        "calendar": "https://triage.layout.team/layout-overflow.json"
-    },
-    "layout-tables":
-    {
-        "calendar": "https://triage.layout.team/layout-tables.json"
-    },
-    "layout-text":
-    {
-        "calendar": "https://triage.layout.team/layout-text.json"
-    },
-    "printing":
-    {
-        "calendar": "https://triage.layout.team/printing.json"
-    },
-    "svg":
-    {
-        "calendar": "https://triage.layout.team/svg.json"
-=======
->>>>>>> Update layout triage calendar URLs
-    }
-}
-<<<<<<< HEAD
->>>>>>> Add round robin config for layout team
-=======
->>>>>>> Update layout triage calendar URLs

--- a/auto_nag/scripts/configs/layout_round_robin.json
+++ b/auto_nag/scripts/configs/layout_round_robin.json
@@ -2,7 +2,11 @@
     "fallback": "Sean Voisen",
     "components":
     {
+<<<<<<< HEAD
         "Core::CSS Transitions and Animations": "animation",
+=======
+        "Core::CSS Animations and Transitions": "animation",
+>>>>>>> Add round robin config for layout team
         "Core::CSS Parsing and Computation": "style-system",
         "Core::DOM: CSS Object Model": "style-system",
         "Core::Layout": "layout-general",
@@ -26,6 +30,7 @@
     },
     "animation":
     {
+<<<<<<< HEAD
         "calendar": "https://triage.layout.team/animation.json"
     },
     "style-system":
@@ -97,3 +102,76 @@
         "calendar": "https://triage.layout.team/svg.json"
     }
 }
+=======
+        "calendar": "https://gecko.layout.team/triage/animation.json"
+    },
+    "style-system":
+    {
+        "calendar": "https://gecko.layout.team/triage/style-system.json"
+    },
+    "layout-general":
+    {
+        "calendar": "https://gecko.layout.team/triage/layout-general.json"
+    },
+    "layout-block-inline":
+    {
+        "calendar": "https://gecko.layout.team/triage/layout-block-inline.json"
+    },
+    "layout-columns":
+    {
+        "calendar": "https://gecko.layout.team/triage/layout-columns.json"
+    },
+    "layout-flex":
+    {
+        "calendar": "https://gecko.layout.team/triage/layout-flex.json"
+    },
+    "layout-floats":
+    {
+        "calendar": "https://gecko.layout.team/triage/layout-floats.json"
+    },
+    "layout-form-controls":
+    {
+        "calendar": "https://gecko.layout.team/triage/layout-form-controls.json"
+    },
+    "layout-generated":
+    {
+        "calendar": "https://gecko.layout.team/triage/layout-generated.json"
+    },
+    "layout-grid":
+    {
+        "calendar": "https://gecko.layout.team/triage/layout-grid.json"
+    },
+    "layout-replaced":
+    {
+        "calendar": "https://gecko.layout.team/triage/layout-replaced.json"
+    },
+    "layout-positioned":
+    {
+        "calendar": "https://gecko.layout.team/triage/layout-positioned.json"
+    },
+    "layout-ruby":
+    {
+        "calendar": "https://gecko.layout.team/triage/layout-ruby.json"
+    },
+    "layout-overflow":
+    {
+        "calendar": "https://gecko.layout.team/triage/layout-overflow.json"
+    },
+    "layout-tables":
+    {
+        "calendar": "https://gecko.layout.team/triage/layout-tables.json"
+    },
+    "layout-text":
+    {
+        "calendar": "https://gecko.layout.team/triage/layout-text.json"
+    },
+    "printing":
+    {
+        "calendar": "https://gecko.layout.team/triage/printing.json"
+    },
+    "svg":
+    {
+        "calendar": "https://gecko.layout.team/triage/svg.json"
+    }
+}
+>>>>>>> Add round robin config for layout team

--- a/auto_nag/scripts/configs/layout_round_robin.json
+++ b/auto_nag/scripts/configs/layout_round_robin.json
@@ -3,10 +3,14 @@
     "components":
     {
 <<<<<<< HEAD
+<<<<<<< HEAD
         "Core::CSS Transitions and Animations": "animation",
 =======
         "Core::CSS Animations and Transitions": "animation",
 >>>>>>> Add round robin config for layout team
+=======
+        "Core::CSS Transitions and Animations": "animation",
+>>>>>>> Update layout triage calendar URLs
         "Core::CSS Parsing and Computation": "style-system",
         "Core::DOM: CSS Object Model": "style-system",
         "Core::Layout": "layout-general",
@@ -32,6 +36,9 @@
     {
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> Update layout triage calendar URLs
         "calendar": "https://triage.layout.team/animation.json"
     },
     "style-system":
@@ -101,6 +108,7 @@
     "svg":
     {
         "calendar": "https://triage.layout.team/svg.json"
+<<<<<<< HEAD
     }
 }
 =======
@@ -176,6 +184,8 @@
     "svg":
     {
         "calendar": "https://triage.layout.team/svg.json"
+=======
+>>>>>>> Update layout triage calendar URLs
     }
 }
 <<<<<<< HEAD


### PR DESCRIPTION
We are moving our triage script to the Mozilla GitHub organization, and changing the URL for the JSON files in the process. This PR updates the config for the layout team appropriately.