### PR TITLE
Add good_first_bug_unassign_inactive rule

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -657,5 +657,12 @@
             "jkratzer@mozilla.com"
         ],
         "max_ni": 1
+    },
+    "good_first_bug_unassign_inactive": {
+        "months_lookup": 6,
+        "receivers":
+        [
+            "sylvestre@mozilla.com"
+        ]
     }
 }

--- a/auto_nag/scripts/good_first_bug_unassign_inactive.py
+++ b/auto_nag/scripts/good_first_bug_unassign_inactive.py
@@ -1,0 +1,57 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from auto_nag import utils
+from auto_nag.bzcleaner import BzCleaner
+
+
+class GoodFirstBugUnassignInactive(BzCleaner):
+    def __init__(self):
+        super(GoodFirstBugUnassignInactive, self).__init__()
+        self.nmonths = utils.get_config(self.name(), "months_lookup")
+        self.autofix_assignee = {}
+
+    def description(self):
+        return "Bugs with good-first-bug keyword and no activity for the last {} months".format(
+            self.nmonths
+        )
+
+    def get_autofix_change(self):
+        return self.autofix_assignee
+
+    def handle_bug(self, bug, data):
+        bugid = str(bug["id"])
+        doc = self.get_documentation()
+
+        self.autofix_assignee[bugid] = {
+            "comment": {
+                "body": "This good-first-bug hasn't had any activity for {} months, it is automatically unassigned.\n{}".format(
+                    self.nmonths, doc
+                )
+            },
+            "reset_assigned_to": True,
+            "status": "NEW",
+        }
+
+        return bug
+
+    def get_bz_params(self, date):
+        fields = ["assigned_to"]
+        params = {
+            "include_fields": fields,
+            "resolution": "---",
+            "f1": "keywords",
+            "o1": "casesubstring",
+            "v1": "good-first-bug",
+            "f2": "days_elapsed",
+            "o2": "greaterthan",
+            "v2": self.nmonths * 30,
+        }
+        utils.get_empty_assignees(params, True)
+
+        return params
+
+
+if __name__ == "__main__":
+    GoodFirstBugUnassignInactive().run()

--- a/runauto_nag_daily.sh
+++ b/runauto_nag_daily.sh
@@ -114,6 +114,9 @@ python -m auto_nag.scripts.stepstoreproduce
 # Update status flags for regressions based on their regressor
 python -m auto_nag.scripts.regression_set_status_flags
 
+# Unassign inactive bugs with the good-first-bug keyword
+python -m auto_nag.scripts.good_first_bug_unassign_inactive
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m auto_nag.log --send

--- a/templates/good_first_bug_unassign_inactive.html
+++ b/templates/good_first_bug_unassign_inactive.html
@@ -1,0 +1,22 @@
+<p>The following good-first-{{ plural('bug has been', data, pword='bugs have been') }} inactive for the last {{ extra['nmonths'] }} {{ plural('month', data) }}:
+<table {{ table_attrs }}>
+  <thead>
+    <tr>
+      <th>Bug</th>
+      <th>Summary</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for i, (bugid, summary) in enumerate(data) -%}
+    <tr {% if i % 2==0 %}bgcolor="#E0E0E0" {% endif -%}>
+      <td>
+        <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+      </td>
+      <td>
+        {{ summary | e }}
+      </td>
+    </tr>
+    {% endfor -%}
+  </tbody>
+</table>
+</p>


### PR DESCRIPTION
This creates a rule that automatically unassigns good-first-bugs for no activity for a long time (6 months atm), and leaves a comment saying why.