### PR TITLE
uplift_beta: skip bugs with checkin-needed-beta in whiteboard

### DIFF
--- a/auto_nag/scripts/uplift_beta.py
+++ b/auto_nag/scripts/uplift_beta.py
@@ -121,6 +121,10 @@ class UpliftBeta(BzCleaner):
             "f8": "attachments.mimetype",
             "o8": "anywordssubstr",
             "v8": "text/x-phabricator-request",
+            # skip if whiteboard contains checkin-needed-beta (e.g. test-only uplift)
+            "f9": "status_whiteboard",
+            "o9": "notsubstring",
+            "v9": "[checkin-needed-beta]",
         }
 
         return params


### PR DESCRIPTION
Just like bugs with pending uplift requests, there's no need to nag in
this case, e.g. https://bugzilla.mozilla.org/show_bug.cgi?id=1688924#c6