### PR TITLE
Don't restrict warn_regressed_by to defect bugs

### DIFF
--- a/auto_nag/scripts/warn_regressed_by.py
+++ b/auto_nag/scripts/warn_regressed_by.py
@@ -75,7 +75,6 @@ class WarnRegressedBy(BzCleaner):
             fields = ["regressed_by"]
             params = {
                 "include_fields": fields,
-                "bug_type": "defect",
                 "f1": "regressed_by",
                 "o1": "isnotempty",
                 "f2": "creation_ts",


### PR DESCRIPTION
This should almost be useless as all regressions should be defects... but you never know.