### PR TITLE
Improve documentation of IAM requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Before running:
 1. The LDAP + SMTP infos are used to send emails
 2. Need to generate an API key from bugzilla admin ( https://bugzilla.mozilla.org/userprefs.cgi?tab=apikey )
 3. Should generate an API key from Phabricator ( https://phabricator.services.mozilla.com/settings/user )
-4. The IAM secrets are used to generate a dump of phonebook, so they're mandatory but you still need to have such a dump
+4. The IAM secrets are used to generate a dump of phonebook, which is required for some scripts ( employees can request by `filing a bug in the SSO: Requests component <https://bugzilla.mozilla.org/enter_bug.cgi?product=Infrastructure%20%26%20Operations&component=SSO%3A%20Requests>`_ )
 5. The private entry contains URLs for private calendar in ICS format:
 
 .. code-block:: json

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Before running:
 1. The LDAP + SMTP infos are used to send emails
 2. Need to generate an API key from bugzilla admin ( https://bugzilla.mozilla.org/userprefs.cgi?tab=apikey )
 3. Should generate an API key from Phabricator ( https://phabricator.services.mozilla.com/settings/user )
-4. The IAM secrets are used to generate a dump of phonebook, which is required for some scripts ( employees can request by `filing a bug in the SSO: Requests component <https://bugzilla.mozilla.org/enter_bug.cgi?product=Infrastructure%20%26%20Operations&component=SSO%3A%20Requests>`_ )
+4. The IAM secrets are used to generate a dump of phonebook, which is required for some scripts (employees can request them by `filing a bug in the SSO: Requests component <https://bugzilla.mozilla.org/enter_bug.cgi?product=Infrastructure%20%26%20Operations&component=SSO%3A%20Requests>`_ )
 5. The private entry contains URLs for private calendar in ICS format:
 
 .. code-block:: json

--- a/auto_nag/iam.py
+++ b/auto_nag/iam.py
@@ -20,6 +20,7 @@ def get_access_token():
             "workgroup",
         ],
         "display": ["staff", "ndaed", "vouched", "authenticated", "public", "none"],
+        "search": ["all"],
     }
     scope = " ".join(
         f"{key}:{value}" for key, values in scope.items() for value in values


### PR DESCRIPTION
- add a pointer towards how to request IAM credentials
- add `search:all` to the list of scopes required: while not needed for
  the code to operate, if your credentials are missing the `search:all`
  scope, our query results in an Internal Server Error