### PR TITLE
Look for changesets that are missing the corresponding bugherder comment

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -665,5 +665,12 @@
         [
             "sylvestre@mozilla.com"
         ]
+    },
+    "missed_landing_comment":
+    {
+        "receivers":
+        [
+            "jcristau@mozilla.com"
+        ]
     }
 }

--- a/auto_nag/scripts/missed_landing_comment.py
+++ b/auto_nag/scripts/missed_landing_comment.py
@@ -1,0 +1,69 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from libmozdata.hgmozilla import Mercurial
+
+from auto_nag import utils
+from auto_nag.bzcleaner import BzCleaner
+
+
+def get_csets_from_pushlog(log):
+    csets = []
+    for push in log["pushes"].values():
+        for cset in push["changesets"]:
+            if any(cset["node"][:12] in c["desc"] for c in push["changesets"]):
+                # if a changeset is mentioned in another in the same central
+                # push, assume it's a backout, and ignore it
+                continue
+            bugs = utils.get_bugs_from_desc(cset["desc"])
+            if not bugs:
+                continue
+            csets.append((cset["node"], bugs[0]))
+    return csets
+
+
+class MissedLandingComment(BzCleaner):
+    def __init__(self):
+        super().__init__()
+        self.bugs = []
+        self.repourl = Mercurial.get_repo_url("nightly")
+
+    def get_bz_params(self, date):
+        start, end = self.get_dates(date)
+        log = utils.get_pushlog(start, end)
+        # get a list of (changeset, bugid) from the mozilla-central pushlog
+        csets = get_csets_from_pushlog(log)
+
+        self.bugs = {}
+        for cset, bug in csets:
+            self.bugs.setdefault(str(bug), []).append(cset)
+
+        params = {
+            "include_fields": ["id", "comments"],
+            "bug_id_type": "anyexact",
+            "bug_id": ",".join(self.bugs),
+        }
+        return params
+
+    def filter_no_nag_keyword(self):
+        return False
+
+    def handle_bug(self, bug, data):
+        bugid = str(bug["id"])
+        assert bugid in self.bugs
+        for cset in self.bugs[bugid]:
+            short = cset[:12]
+            cseturl = "%s/rev/%s" % (self.repourl, short)
+            if any(cseturl in comment["text"] for comment in bug["comments"]):
+                continue
+            if bugid not in data:
+                data[bugid] = {"id": bugid, "missing_csets": []}
+            data[bugid]["missing_csets"].append((cset, cseturl))
+
+    def columns(self):
+        return ["id", "missing_csets"]
+
+
+if __name__ == "__main__":
+    MissedLandingComment().run()

--- a/runauto_nag_daily.sh
+++ b/runauto_nag_daily.sh
@@ -117,6 +117,9 @@ python -m auto_nag.scripts.regression_set_status_flags
 # Unassign inactive bugs with the good-first-bug keyword
 python -m auto_nag.scripts.good_first_bug_unassign_inactive
 
+# Look for missing bugzilla comments for recently-landed changesets
+python -m auto_nag.scripts.missed_landing_comment
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m auto_nag.log --send

--- a/templates/missed_landing_comment.html
+++ b/templates/missed_landing_comment.html
@@ -1,0 +1,23 @@
+<p>The following bugs haven't been updated with a commit referencing them:
+  <table {{ table_attrs }}>
+    <thead>
+      <tr>
+        <th>Bug</th><th>Changeset</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for i, (bugid, csets) in enumerate(data) -%}
+      <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+        <td>
+          <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+        </td>
+        <td>
+          {% for cset in csets %}
+          <a href="{{ cset[1] | e }}">{{ cset[0]}}</a>
+          {% endfor %}
+        </td>
+      </tr>
+      {% endfor -%}
+    </tbody>
+  </table>
+<p>


### PR DESCRIPTION
Go through the mozilla-central pushlog, and warn if a (non-backed-out)
changeset is not mentioned in any comment in the corresponding bug.

Fixes #1063