### PR TITLE
Enable spam bug detection in all products

### DIFF
--- a/auto_nag/scripts/spambug.py
+++ b/auto_nag/scripts/spambug.py
@@ -26,6 +26,9 @@ class SpamBug(BzCleaner):
     def description(self):
         return "[Using ML] Detect spam bugs"
 
+    def has_default_products(self):
+        return False
+
     def columns(self):
         return ["id", "summary", "confidence"]
 


### PR DESCRIPTION
The training only happens on specific products, so there is a chance this will not work so well for other products. If it finds too many false positives, then I will extend the training set to contain all products too.