### PR TITLE
Add leave_open_sec nag

### DIFF
--- a/auto_nag/bzcleaner.py
+++ b/auto_nag/bzcleaner.py
@@ -3,8 +3,8 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import argparse
-import inspect
 import os
+import sys
 import time
 
 import six
@@ -31,24 +31,12 @@ class BzCleaner(object):
         self.versions = None
         logger.info("Run tool {}".format(self.get_tool_path()))
 
-    def _is_a_bzcleaner_init(self, info):
-        if info[3] == "__init__":
-            frame = info[0]
-            args = inspect.getargvalues(frame)
-            if "self" in args.locals:
-                zelf = args.locals["self"]
-                return isinstance(zelf, BzCleaner)
-        return False
-
     def _set_tool_name(self):
-        stack = inspect.stack()
-        init = [s for s in stack if self._is_a_bzcleaner_init(s)]
-        last = init[-1]
-        info = inspect.getframeinfo(last[0])
+        module = sys.modules[self.__class__.__module__]
         base = os.path.dirname(__file__)
         scripts = os.path.join(base, "scripts")
-        self.__tool_path__ = os.path.relpath(info.filename, scripts)
-        name = os.path.basename(info.filename)
+        self.__tool_path__ = os.path.relpath(module.__file__, scripts)
+        name = os.path.basename(module.__file__)
         name = os.path.splitext(name)[0]
         self.__tool_name__ = name
 

--- a/auto_nag/scripts/close_intermittents.py
+++ b/auto_nag/scripts/close_intermittents.py
@@ -6,9 +6,6 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class Intermittents(BzCleaner):
-    def __init__(self):
-        super(Intermittents, self).__init__()
-
     def description(self):
         return "Intermittent test failure bugs unchanged in 21 days"
 

--- a/auto_nag/scripts/closed_dupeme.py
+++ b/auto_nag/scripts/closed_dupeme.py
@@ -6,9 +6,6 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class DupeMe(BzCleaner):
-    def __init__(self):
-        super(DupeMe, self).__init__()
-
     def description(self):
         return "Closed bugs with dupeme keyword"
 

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -674,5 +674,13 @@
             "shengst@mozilla.com",
             "jcristau@mozilla.com"
         ]
+    },
+    "leave_open_sec":
+    {
+        "receivers":
+        [
+            "release-mgmt@mozilla.com"
+        ],
+        "days_lookup": 2
     }
 }

--- a/auto_nag/scripts/defect_with_please_or_enable.py
+++ b/auto_nag/scripts/defect_with_please_or_enable.py
@@ -6,9 +6,6 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class DefectWithPlease(BzCleaner):
-    def __init__(self):
-        super(DefectWithPlease, self).__init__()
-
     def description(self):
         return (
             "Defect with description starting with 'Please', 'Enable', 'Disable', etc"

--- a/auto_nag/scripts/feature_but_type_defect_task.py
+++ b/auto_nag/scripts/feature_but_type_defect_task.py
@@ -6,9 +6,6 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class RegressionButDefectTask(BzCleaner):
-    def __init__(self):
-        super(RegressionButDefectTask, self).__init__()
-
     def description(self):
         return "Defect or task with the 'feature' keyword"
 

--- a/auto_nag/scripts/feature_regression.py
+++ b/auto_nag/scripts/feature_regression.py
@@ -6,9 +6,6 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class FeatureRegression(BzCleaner):
-    def __init__(self):
-        super(FeatureRegression, self).__init__()
-
     def description(self):
         return "Bugs with feature and regression keywords"
 

--- a/auto_nag/scripts/fuzzing_bisection_without_regressed_by.py
+++ b/auto_nag/scripts/fuzzing_bisection_without_regressed_by.py
@@ -11,9 +11,6 @@ MAX_DEPTH = 2
 
 
 class FuzzingBisectionWithoutRegressedBy(BzCleaner):
-    def __init__(self):
-        super(FuzzingBisectionWithoutRegressedBy, self).__init__()
-
     def description(self):
         return "Bugs with a fuzzing bisection and without regressed_by"
 

--- a/auto_nag/scripts/has_str_no_hasstr.py
+++ b/auto_nag/scripts/has_str_no_hasstr.py
@@ -14,9 +14,6 @@ STR = re.compile(r"^(?:Step[s]? to reproduce|STR|Step[s]?)[ \t]*:", re.I | re.MU
 
 
 class HasStrNoHasstr(BzCleaner):
-    def __init__(self):
-        super(HasStrNoHasstr, self).__init__()
-
     def description(self):
         return "Bugs with no has_str and STR in the first comment"
 

--- a/auto_nag/scripts/leave_open.py
+++ b/auto_nag/scripts/leave_open.py
@@ -6,9 +6,6 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class LeaveOpen(BzCleaner):
-    def __init__(self):
-        super(LeaveOpen, self).__init__()
-
     def description(self):
         return "Closed bugs with leave-open keyword"
 

--- a/auto_nag/scripts/leave_open_sec.py
+++ b/auto_nag/scripts/leave_open_sec.py
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from auto_nag import utils
+from auto_nag.bzcleaner import BzCleaner
+
+
+class LeaveOpenSec(BzCleaner):
+    def description(self):
+        return "Security bugs with leave-open keyword"
+
+    def get_bz_params(self, date):
+        start, end = self.get_dates(date)
+        bugs = utils.get_bugs_from_pushlog(start, end)
+        params = {
+            "bug_id": list(bugs),
+            "keywords": "leave-open",
+            "f1": "bug_group",
+            "o1": "substring",
+            "v1": "security",
+        }
+        return params
+
+    def columns(self):
+        return ["id"]
+
+
+if __name__ == "__main__":
+    LeaveOpenSec().run()

--- a/auto_nag/scripts/one_two_word_summary.py
+++ b/auto_nag/scripts/one_two_word_summary.py
@@ -6,9 +6,6 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class OneTwoWordSummary(BzCleaner):
-    def __init__(self):
-        super(OneTwoWordSummary, self).__init__()
-
     def description(self):
         return "Bugs with only one or two words in the summary"
 

--- a/auto_nag/scripts/regression_but_type_enhancement_task.py
+++ b/auto_nag/scripts/regression_but_type_enhancement_task.py
@@ -6,9 +6,6 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class RegressionButEnhancementTask(BzCleaner):
-    def __init__(self):
-        super(RegressionButEnhancementTask, self).__init__()
-
     def description(self):
         return (
             'Enhancement or task with the "regression", "crash" or "assertion" keyword'

--- a/auto_nag/scripts/regression_without_regressed_by.py
+++ b/auto_nag/scripts/regression_without_regressed_by.py
@@ -10,9 +10,6 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class RegressionWithoutRegressedBy(BzCleaner):
-    def __init__(self):
-        super(RegressionWithoutRegressedBy, self).__init__()
-
     def description(self):
         return "Regressions without regressed_by and some dependencies"
 

--- a/auto_nag/scripts/stalled.py
+++ b/auto_nag/scripts/stalled.py
@@ -6,9 +6,6 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class Stalled(BzCleaner):
-    def __init__(self):
-        super(Stalled, self).__init__()
-
     def description(self):
         return "Closed bugs with stalled keyword"
 

--- a/auto_nag/scripts/stepstoreproduce.py
+++ b/auto_nag/scripts/stepstoreproduce.py
@@ -8,9 +8,6 @@ from auto_nag.utils import nice_round
 
 
 class StepsToReproduce(BzCleaner):
-    def __init__(self):
-        super().__init__()
-
     def description(self):
         return "[Using ML] Bugs with missing steps to reproduce"
 

--- a/auto_nag/scripts/summary_meta_missing.py
+++ b/auto_nag/scripts/summary_meta_missing.py
@@ -6,9 +6,6 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class MetaSummaryMissing(BzCleaner):
-    def __init__(self):
-        super(MetaSummaryMissing, self).__init__()
-
     def description(self):
         return "Bugs without the meta keyword but with [meta] in the title"
 

--- a/auto_nag/scripts/topcrash_bad_severity.py
+++ b/auto_nag/scripts/topcrash_bad_severity.py
@@ -6,9 +6,6 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class TopcrashBadSeverity(BzCleaner):
-    def __init__(self):
-        super(TopcrashBadSeverity, self).__init__()
-
     def description(self):
         return "Bugs with topcrash keyword but incorrect severity"
 

--- a/auto_nag/scripts/untriage_important_sev.py
+++ b/auto_nag/scripts/untriage_important_sev.py
@@ -6,9 +6,6 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class UntriagedWithImportantSev(BzCleaner):
-    def __init__(self):
-        super(UntriagedWithImportantSev, self).__init__()
-
     def description(self):
         return "Bugs in untriaged with an important severity"
 

--- a/auto_nag/scripts/workflow/p2_merge_day.py
+++ b/auto_nag/scripts/workflow/p2_merge_day.py
@@ -9,9 +9,6 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class P2MergeDay(BzCleaner):
-    def __init__(self):
-        super(P2MergeDay, self).__init__()
-
     def must_run(self, date):
         cal = rc.get_calendar()
         for c in cal:

--- a/runauto_nag_daily.sh
+++ b/runauto_nag_daily.sh
@@ -120,6 +120,9 @@ python -m auto_nag.scripts.good_first_bug_unassign_inactive
 # Look for missing bugzilla comments for recently-landed changesets
 python -m auto_nag.scripts.missed_landing_comment
 
+# Look for recently landed changesets referencing leave-open security bugs
+python -m auto_nag.scripts.leave_open_sec
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m auto_nag.log --send

--- a/templates/leave_open_sec.html
+++ b/templates/leave_open_sec.html
@@ -1,0 +1,18 @@
+<p>Commits referencing the following security bugs have landed, and the bugs have the leave-open keyword, please double check them:
+  <table {{ table_attrs }}>
+    <thead>
+      <tr>
+        <th>Bug</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for i, bugid in enumerate(data) -%}
+      <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+        <td>
+          <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+        </td>
+      </tr>
+      {% endfor -%}
+    </tbody>
+  </table>
+<p>


### PR DESCRIPTION
Look for commits referencing security bugs with the leave-open keyword, so someone can double check the landed patch is just a diagnostic; this should avoid missing fixes and backports where e.g. the developer is keeping the bug open for purposes of landing a test later.

To cut down on the noise, this only looks at changes in the previous 2 days.  That should still cover weekends, I think, in case the script only runs Monday-Friday.

The PR also includes an unrelated cleanup for something I noticed while writing this: inspecting the stack in `BzCleaner._set_tool_name` meant that a no-op `__init__` method was required for all tools.  So I'm getting rid of that.