### PR TITLE
Add X-Mailer email header

### DIFF
--- a/auto_nag/mail.py
+++ b/auto_nag/mail.py
@@ -88,6 +88,7 @@ def send(
     message["Subject"] = Subject
     message["Cc"] = ", ".join(Cc)
     message["Bcc"] = ", ".join(Bcc)
+    message["X-Mailer"] = "relman-auto-nag"
 
     if subtype == "html":
         Body = replaceUnicode(Body)


### PR DESCRIPTION
Adds an `X-Mailer` header to all emails.  This simplifies the authoring
email filters that perform actions on all auto-nag generated content
regardless of sender/subject/etc.