### PR TITLE
Copy-duplicat-info - Avoid to nag forever because a bug hasn't a cf_crash_signature field

### DIFF
--- a/auto_nag/scripts/copy_duplicate_info.py
+++ b/auto_nag/scripts/copy_duplicate_info.py
@@ -70,7 +70,7 @@ class CopyDuplicateInfo(BzCleaner):
         data[bugid] = {
             "id": bugid,
             "summary": self.get_summary(bug),
-            "signature": bug.get("cf_crash_signature", ""),
+            "signature": bug.get("cf_crash_signature", None),
             "dupe": str(bug["dupe_of"]),
             "product": bug["product"],
             "component": bug["component"],
@@ -117,6 +117,10 @@ class CopyDuplicateInfo(BzCleaner):
 
             dup = dups[dupid]
             bs = utils.get_signatures(info["signature"])
+            if dup["signature"] is None:
+                # some bugs don't have a cf_crash_signature field... it's weird
+                # but it's life...
+                continue
             ds = utils.get_signatures(dup["signature"])
             if not bs.issubset(ds):
                 signatures[dupid] = bs - ds


### PR DESCRIPTION
The bug here: https://bugzilla.mozilla.org/show_bug.cgi?id=1572618
hasn't a signature field and consequently we get some nag mails every hour...