### PR TITLE
Consider bugs filed in the Firefox::Foxfooding as untriaged bugs

### DIFF
--- a/auto_nag/scripts/component.py
+++ b/auto_nag/scripts/component.py
@@ -71,8 +71,8 @@ class Component(BzCleaner):
             "v6": start_date,
             "f7": "CP",
             "f8": "component",
-            "o8": "equals",
-            "v8": "Untriaged",
+            "o8": "anyexact",
+            "v8": "Untriaged,Foxfooding",
             "f9": "CP",
         }
 


### PR DESCRIPTION
The Foxfooding component's description is "Bugs found through the
foxfooding program will be filed in this component to be later
triaged to the appropriate buckets."