### PR TITLE
Enable tool to nag about bugs assigned to inactive accounts

### DIFF
--- a/auto_nag/scripts/assignee_no_login.py
+++ b/auto_nag/scripts/assignee_no_login.py
@@ -74,7 +74,7 @@ class AssigneeNoLogin(BzCleaner):
             "v1": start_date,
             "f2": "days_elapsed",
             "o2": "lessthan",
-            "v2": self.last_activity_months * 3,
+            "v2": self.last_activity_months * 30,
         }
 
         utils.get_empty_assignees(params, negation=True)

--- a/auto_nag/scripts/assignee_no_login.py
+++ b/auto_nag/scripts/assignee_no_login.py
@@ -69,6 +69,9 @@ class AssigneeNoLogin(BzCleaner):
             "f1": "assignee_last_login",
             "o1": "lessthan",
             "v1": start_date,
+            "f2": "days_elapsed",
+            "o2": "lessthan",
+            "v2": 90,
         }
 
         utils.get_empty_assignees(params, negation=True)

--- a/auto_nag/scripts/assignee_no_login.py
+++ b/auto_nag/scripts/assignee_no_login.py
@@ -13,6 +13,9 @@ class AssigneeNoLogin(BzCleaner):
     def __init__(self):
         super(AssigneeNoLogin, self).__init__()
         self.nmonths = utils.get_config(self.name(), "number_of_months", 12)
+        self.last_activity_months = utils.get_config(
+            self.name(), "last_activity_months", 3
+        )
         self.autofix_assignee = {}
         self.default_assignees = utils.get_default_assignees()
         self.people = people.People.get_instance()
@@ -71,7 +74,7 @@ class AssigneeNoLogin(BzCleaner):
             "v1": start_date,
             "f2": "days_elapsed",
             "o2": "lessthan",
-            "v2": 90,
+            "v2": self.last_activity_months * 3,
         }
 
         utils.get_empty_assignees(params, negation=True)

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -185,7 +185,7 @@
     },
     "assignee_no_login":
     {
-        "number_of_months": 12
+        "number_of_months": 7
     },
     "not_landed":
     {

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -185,7 +185,8 @@
     },
     "assignee_no_login":
     {
-        "number_of_months": 7
+        "number_of_months": 7,
+        "last_activity_months": 3
     },
     "not_landed":
     {

--- a/runauto_nag_daily.sh
+++ b/runauto_nag_daily.sh
@@ -138,6 +138,9 @@ python -m auto_nag.scripts.telemetry_expiry_tracking_autoapproval
 # Set "Has Regression Range" to "yes" on bugs where "Regressed By" is set
 python -m auto_nag.scripts.regressed_by_no_has_regression_range
 
+# Needinfo triage owner on bugs assigned to inactive accounts
+python -m auto_nag.scripts.assignee_no_login
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m auto_nag.log --send

--- a/templates/assignee_no_login_needinfo.txt
+++ b/templates/assignee_no_login_needinfo.txt
@@ -1,2 +1,3 @@
 The bug assignee didn't login in Bugzilla in the last {{ extra['nmonths'] }} {{ plural('month', extra['nmonths']) }}.
 :{{ nickname }}, could you have a look please?
+{{ documentation }}

--- a/templates/leave_open_no_activity_needinfo.txt
+++ b/templates/leave_open_no_activity_needinfo.txt
@@ -1,2 +1,3 @@
 The leave-open keyword is there and there is no activity for {{ extra['nmonths'] }} {{ plural('month', extra['nmonths']) }}.
 :{{ nickname }}, maybe it's time to close this bug?
+{{ documentation }}


### PR DESCRIPTION
I added a limit on last activity to avoid a large number of needinfos. We can progressively increase the limit after the first batch of bugs have been handled and we can remove the limit once all the backlog has been resolved.

First step of #266