### PR TITLE
Needinfo for bugs with inconsistent severity flags

### DIFF
--- a/auto_nag/scripts/severity_inconsistency.py
+++ b/auto_nag/scripts/severity_inconsistency.py
@@ -1,0 +1,88 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from auto_nag import utils
+from auto_nag.bzcleaner import BzCleaner
+
+
+class SeverityInconsistency(BzCleaner):
+
+    def description(self):
+        return "Bugs with inconsistent severity flags"
+
+    def has_needinfo(self):
+        return True
+
+    def handle_bug(self, bug, data):
+        self.extra_ni = data
+
+        bugid = str(bug["id"])
+
+        def is_security_flag(flag):
+            return flag.startswith("[access-s")
+
+        flags = bug['whiteboard'].split(", ")
+        whiteboard_severity = next(filter(is_security_flag, flags), None)
+
+        data[bugid] = {
+            "whiteboard_severity": whiteboard_severity,
+            "severity": bug["severity"],
+        }
+
+        return bug
+
+    def get_extra_for_needinfo_template(self):
+        return self.extra_ni
+
+    def columns(self):
+        return ["id", "summary", "severity", "whiteboard_severity"]
+
+    def get_mail_to_auto_ni(self, bug):
+        for f in ["assigned_to", "triage_owner"]:
+            person = bug.get(f, "")
+            if person and not utils.is_no_assignee(person):
+                return {"mail": person, "nickname": bug[f + "_detail"]["nick"]}
+
+        return None
+
+    def get_bz_params(self, date):
+        fields = ["triage_owner", "assigned_to", "severity", "whiteboard"]
+
+        params = {
+            "include_fields": fields,
+            "resolution": "---",
+            "j1": "OR",
+            "f1": "OP",
+            "f2": "OP",
+            "f3": "status_whiteboard",
+            "o3": "anywordssubstr",
+            "v3": "access-s3",
+            "f4": "bug_severity",
+            "o4": "anyexact",
+            "v4": "S4",
+            "f5": "CP",
+            "f6": "OP",
+            "f7": "status_whiteboard",
+            "o7": "anywordssubstr",
+            "v7": "access-s1",
+            "f8": "bug_severity",
+            "o8": "anyexact",
+            "v8": "S2,S3,S4",
+            "f9": "CP",
+            "f10": "OP",
+            "f11": "status_whiteboard",
+            "o11": "anywordssubstr",
+            "v11": "access-s2",
+            "f12": "bug_severity",
+            "o12": "anyexact",
+            "v12": "S3,S4",
+            "f13": "CP",
+            "f14": "CP",
+        }
+
+        return params
+
+
+if __name__ == "__main__":
+    SeverityInconsistency().run()

--- a/auto_nag/scripts/severity_inconsistency.py
+++ b/auto_nag/scripts/severity_inconsistency.py
@@ -7,7 +7,7 @@ import re
 from auto_nag import utils
 from auto_nag.bzcleaner import BzCleaner
 
-WHITEBOARD_PAT = re.compile(r"\][,; ]*?\[")
+WHITEBOARD_PAT = re.compile(r"\[access\-s[123]\]")
 
 
 class SeverityInconsistency(BzCleaner):
@@ -18,8 +18,7 @@ class SeverityInconsistency(BzCleaner):
         return True
 
     def handle_bug(self, bug, data):
-        flags = WHITEBOARD_PAT.split(bug["whiteboard"][1:-1])
-        whiteboard_severities = [flag for flag in flags if flag.startswith("access-s")]
+        whiteboard_severities = WHITEBOARD_PAT.findall(bug["whiteboard"])
         assert len(whiteboard_severities) == 1
         whiteboard_severity = whiteboard_severities[0]
 

--- a/auto_nag/scripts/severity_inconsistency.py
+++ b/auto_nag/scripts/severity_inconsistency.py
@@ -7,7 +7,6 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class SeverityInconsistency(BzCleaner):
-
     def description(self):
         return "Bugs with inconsistent severity flags"
 
@@ -22,7 +21,7 @@ class SeverityInconsistency(BzCleaner):
         def is_security_flag(flag):
             return flag.startswith("[access-s")
 
-        flags = bug['whiteboard'].split(", ")
+        flags = bug["whiteboard"].split(", ")
         whiteboard_severity = next(filter(is_security_flag, flags), None)
 
         data[bugid] = {

--- a/auto_nag/scripts/severity_inconsistency.py
+++ b/auto_nag/scripts/severity_inconsistency.py
@@ -79,6 +79,10 @@ class SeverityInconsistency(BzCleaner):
             "v12": "S3,S4",
             "f13": "CP",
             "f14": "CP",
+            "n15": 1,
+            "f15": "longdesc",
+            "o15": "casesubstring",
+            "v15": "could you consider increasing the severity?",
         }
 
         return params

--- a/runauto_nag_daily.sh
+++ b/runauto_nag_daily.sh
@@ -141,6 +141,9 @@ python -m auto_nag.scripts.regressed_by_no_has_regression_range
 # Needinfo triage owner on bugs assigned to inactive accounts
 python -m auto_nag.scripts.assignee_no_login
 
+# Needinfo for bugs with inconsistent severity flags
+python -m auto_nag.scripts.severity_inconsistency
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m auto_nag.log --send

--- a/templates/severity_inconsistency.html
+++ b/templates/severity_inconsistency.html
@@ -1,0 +1,27 @@
+<p>The following {{ plural('bug has', data, pword='bugs have') }} inconsistency between the bug severity and Whiteboard severity flag. {{ plural('Owner', data) }} got {{ plural('a needinfo request', data, pword='needinfo requests') }} to bump the severity:
+    <table {{ table_attrs }}>
+      <thead>
+        <tr>
+          <th>Bug</th><th>Summary</th><th>Severity</th><th>Whiteboard Flag</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for i, (bugid, summary, severity, whiteboard_severity) in enumerate(data) -%}
+        <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+          <td>
+            <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+           </td>
+          <td>
+            {{ summary | e }}
+          </td>
+          <td>
+            {{ severity }}
+          </td>
+          <td>
+            {{ whiteboard_severity }}
+          </td>
+        </tr>
+        {% endfor -%}
+      </tbody>
+    </table>
+</p>

--- a/templates/severity_inconsistency_needinfo.txt
+++ b/templates/severity_inconsistency_needinfo.txt
@@ -1,4 +1,4 @@
-The severity field for this bug is set for to {{ extra[bugid]["severity"] }}, however, Whiteboard shows a higher severity with the flag {{ extra[bugid]["whiteboard_severity"] }}.
+The severity field for this bug is set to {{ extra[bugid]["severity"] }}. However, the accessibility severity is higher, {{ extra[bugid]["whiteboard_severity"] }}.
 :{{ nickname }}, could you have a look please?
 
 {{ documentation }}

--- a/templates/severity_inconsistency_needinfo.txt
+++ b/templates/severity_inconsistency_needinfo.txt
@@ -1,0 +1,4 @@
+The severity field for this bug is set for to {{ extra[bugid]["severity"] }}, however, Whiteboard shows a higher severity with the flag {{ extra[bugid]["whiteboard_severity"] }}.
+:{{ nickname }}, could you have a look please?
+
+{{ documentation }}

--- a/templates/severity_inconsistency_needinfo.txt
+++ b/templates/severity_inconsistency_needinfo.txt
@@ -1,4 +1,4 @@
 The severity field for this bug is set to {{ extra[bugid]["severity"] }}. However, the accessibility severity is higher, {{ extra[bugid]["whiteboard_severity"] }}.
-:{{ nickname }}, could you have a look please?
+:{{ nickname }}, could you consider increasing the severity?
 
 {{ documentation }}


### PR DESCRIPTION
This should resolve #1290.

The new script should be reflected on the [Autonag wiki page](https://wiki.mozilla.org/Release_Management/autonag). The following is the proposed addition to the wiki page:

**Bugs with inconsistent severity flags**

**Purpose**   | Make sure that bugs severity is consistent with the [accessibility severity](https://wiki.mozilla.org/Accessibility/Triage#Triaging_Firefox_and_Gecko_feature_defects) on the Whiteboard 
--- | ---
**Action** 	| Needinfo the assignee or the triage owner if not assigned yet 
**Code** 	| [severity_inconsistency.py](https://github.com/mozilla/relman-auto-nag/blob/master/auto_nag/scripts/severity_inconsistency.py)


---------


I have the following questions:
- Do we need to limit the bug type to `defect`? Currently is not.
- Do we need to select products or components? Currently is not.
- Should we send the `needinfo` request to Mozilla employees only? Currently not checking.


