### PR TITLE
Needinfo for bugs with underestimated severity levels

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -174,6 +174,14 @@
     "receivers": ["sledru@mozilla.com", "release-mgmt@mozilla.com"],
     "must_run": ["Mon"]
   },
+  "severity_underestimated": {
+    "weeks_lookup": 3,
+    "number_dups": 3,
+    "number_votes": 10,
+    "number_cc": 50,
+    "receivers": ["sledru@mozilla.com", "release-mgmt@mozilla.com"],
+    "must_run": ["Mon"]
+  },
   "closed_dupeme": {
     "days_lookup": 100
   },

--- a/auto_nag/scripts/severity_underestimated.py
+++ b/auto_nag/scripts/severity_underestimated.py
@@ -1,0 +1,130 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from auto_nag import utils
+from auto_nag.bzcleaner import BzCleaner
+
+
+class UnderestimatedSeverity(BzCleaner):
+    def __init__(self):
+        super(UnderestimatedSeverity, self).__init__()
+        self.nweeks = utils.get_config(self.name(), "weeks_lookup")
+        self.ndups = utils.get_config(self.name(), "number_dups")
+        self.votes = utils.get_config("lot_of_votes", "number_votes")
+        self.cc = utils.get_config("lot_of_cc", "number_cc")
+
+        self.extra_ni = {}
+
+    def description(self):
+        return "Bugs with underestemated severity for the last {} weeks".format(
+            self.nweeks
+        )
+
+    def has_needinfo(self):
+        return True
+
+    def get_mail_to_auto_ni(self, bug):
+        for field in ["assigned_to", "triage_owner"]:
+            person = bug.get(field, "")
+            if person and not utils.is_no_assignee(person):
+                return {"mail": person, "nickname": bug[f"{field}_detail"]["nick"]}
+
+        return None
+
+    def get_extra_for_needinfo_template(self):
+        return self.extra_ni
+
+    def columns(self):
+        return [
+            "id",
+            "summary",
+            "creation",
+            "last_change",
+            "severity",
+            "dups_count",
+            "votes",
+            "cc_count",
+        ]
+
+    def get_extra_for_template(self):
+        return {
+            "dups_threshold": self.ndups,
+            "votes_threshold": self.votes,
+            "cc_threshold": self.cc,
+        }
+
+    def handle_bug(self, bug, data):
+        bugid = str(bug["id"])
+        cc_count = len(bug["cc"])
+        dups_count = len(bug["duplicates"])
+
+        data[bugid] = {
+            "creation": utils.get_human_lag(bug["creation_time"]),
+            "last_change": utils.get_human_lag(bug["last_change_time"]),
+            "severity": bug["severity"],
+            "dups_count": dups_count,
+            "votes": bug["votes"],
+            "cc_count": cc_count,
+        }
+
+        factors = []
+        if dups_count >= self.ndups:
+            factors.append("duplicates")
+        if bug["votes"] >= self.votes:
+            factors.append("votes")
+        if cc_count >= self.cc:
+            factors.append("CCs")
+
+        self.extra_ni[bugid] = {
+            "severity": bug["severity"],
+            "factors": utils.english_list(factors),
+        }
+
+        return bug
+
+    def get_bz_params(self, date):
+        fields = [
+            "assigned_to",
+            "triage_owner",
+            "creation_time",
+            "last_change_time",
+            "severity",
+            "votes",
+            "cc",
+            "duplicates",
+        ]
+
+        params = {
+            "include_fields": fields,
+            "resolution": "---",
+            "bug_severity": ["S3", "S4"],
+            "f1": "keywords",
+            "o1": "nowords",
+            "v1": ["meta", "intermittent"],
+            "f2": "days_elapsed",
+            "o2": "lessthan",
+            "v2": self.nweeks * 7,
+            "j3": "OR",
+            "f3": "OP",
+            "f4": "dupe_count",
+            "o4": "greaterthaneq",
+            "v4": self.ndups,
+            "f5": "votes",
+            "o5": "greaterthaneq",
+            "v5": self.votes,
+            "f6": "cc_count",
+            "o6": "greaterthaneq",
+            "v6": self.cc,
+            "f7": "CP",
+            "n15": 1,
+            "f15": "longdesc",
+            "o15": "casesubstring",
+            "v15": "could you consider increasing the severity?",
+        }
+
+        return params
+
+
+if __name__ == "__main__":
+    UnderestimatedSeverity().run()

--- a/auto_nag/scripts/severity_underestimated.py
+++ b/auto_nag/scripts/severity_underestimated.py
@@ -99,6 +99,7 @@ class UnderestimatedSeverity(BzCleaner):
         params = {
             "include_fields": fields,
             "resolution": "---",
+            "bug_type": "defect",
             "bug_severity": ["S3", "S4"],
             "f1": "keywords",
             "o1": "nowords",

--- a/auto_nag/scripts/severity_underestimated.py
+++ b/auto_nag/scripts/severity_underestimated.py
@@ -58,23 +58,24 @@ class UnderestimatedSeverity(BzCleaner):
         bugid = str(bug["id"])
         cc_count = len(bug["cc"])
         dups_count = len(bug["duplicates"])
+        votes_count = bug["votes"]
 
         data[bugid] = {
             "creation": utils.get_human_lag(bug["creation_time"]),
             "last_change": utils.get_human_lag(bug["last_change_time"]),
             "severity": bug["severity"],
             "dups_count": dups_count,
-            "votes": bug["votes"],
+            "votes": votes_count,
             "cc_count": cc_count,
         }
 
         factors = []
         if dups_count >= self.ndups:
-            factors.append("duplicates")
-        if bug["votes"] >= self.votes:
-            factors.append("votes")
+            factors.append(f"{dups_count} duplicates")
+        if votes_count >= self.votes:
+            factors.append(f"{votes_count} votes")
         if cc_count >= self.cc:
-            factors.append("CCs")
+            factors.append(f"{cc_count} CCs")
 
         self.extra_ni[bugid] = {
             "severity": bug["severity"],

--- a/auto_nag/scripts/severity_underestimated.py
+++ b/auto_nag/scripts/severity_underestimated.py
@@ -121,7 +121,7 @@ class UnderestimatedSeverity(BzCleaner):
             "n15": 1,
             "f15": "longdesc",
             "o15": "casesubstring",
-            "v15": "could you consider increasing the severity?",
+            "v15": "could you consider increasing the bug severity?",
         }
 
         return params

--- a/auto_nag/utils.py
+++ b/auto_nag/utils.py
@@ -152,6 +152,14 @@ def plural(sword, data, pword=""):
     return sword + "s"
 
 
+def english_list(items):
+    assert len(items) > 0
+    if len(items) == 1:
+        return items[0]
+
+    return "{} and {}".format(", ".join(items[:-1]), items[-1])
+
+
 def split_long_url(url):
     if not url:
         return url

--- a/runauto_nag_daily.sh
+++ b/runauto_nag_daily.sh
@@ -144,6 +144,9 @@ python -m auto_nag.scripts.assignee_no_login
 # Needinfo for bugs with inconsistent severity flags
 python -m auto_nag.scripts.severity_inconsistency
 
+# Needinfo for bugs with underestimated severity levels
+python -m auto_nag.scripts.severity_underestimated
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m auto_nag.log --send

--- a/templates/severity_underestimated.html
+++ b/templates/severity_underestimated.html
@@ -1,0 +1,46 @@
+<p>The following {{ plural('bug has', data, pword='bugs have') }} potential higher severity:
+  <table {{ table_attrs }}>
+    <thead>
+      <tr>
+        <th>Bug</th>
+        <th>Summary</th>
+        <th>Creation</th>
+        <th>Last comment</th>
+        <th>Severity</th>
+        <th>Duplicates</th>
+        <th>Votes</th>
+        <th>CC</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for i, (bugid, summary, creation, last_change, severity, dups_count, votes, cc_count) in enumerate(data) -%}
+      <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+        <td>
+          <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+        </td>
+        <td>
+          {{ summary | e }}
+        </td>
+        <td>
+          {{ creation }}
+        </td>
+        <td>
+          {{ last_change }}
+        </td>
+        <td>
+          {{ severity }}
+        </td>
+        <td {% if dups_count >= extra["dups_threshold"] %}bgcolor="#FFB8B8"{% endif -%}>
+          {{ dups_count }}
+        </td>
+        <td {% if votes >= extra["votes_threshold"] %}bgcolor="#FFB8B8"{% endif -%}>
+          {{ votes }}
+        </td>
+        <td {% if cc_count >= extra["cc_threshold"] %}bgcolor="#FFB8B8"{% endif -%}>
+          {{ cc_count }}
+        </td>
+      </tr>
+      {% endfor -%}
+    </tbody>
+  </table>
+</p>

--- a/templates/severity_underestimated_needinfo.txt
+++ b/templates/severity_underestimated_needinfo.txt
@@ -1,0 +1,4 @@
+The severity field for this bug is relatively low, {{ extra[bugid]["severity"] }}. However, the bug has many {{ extra[bugid]["factors"] }}.
+:{{ nickname }}, could you consider increasing the severity?
+
+{{ documentation }}

--- a/templates/severity_underestimated_needinfo.txt
+++ b/templates/severity_underestimated_needinfo.txt
@@ -1,4 +1,4 @@
-The severity field for this bug is relatively low, {{ extra[bugid]["severity"] }}. However, the bug has many {{ extra[bugid]["factors"] }}.
+The severity field for this bug is relatively low, {{ extra[bugid]["severity"] }}. However, the bug has {{ extra[bugid]["factors"] }}.
 :{{ nickname }}, could you consider increasing the severity?
 
 {{ documentation }}

--- a/templates/severity_underestimated_needinfo.txt
+++ b/templates/severity_underestimated_needinfo.txt
@@ -1,4 +1,4 @@
 The severity field for this bug is relatively low, {{ extra[bugid]["severity"] }}. However, the bug has {{ extra[bugid]["factors"] }}.
-:{{ nickname }}, could you consider increasing the severity?
+:{{ nickname }}, could you consider increasing the bug severity?
 
 {{ documentation }}


### PR DESCRIPTION
This should resolve #1184.

## Autonag wiki page

**Bugs with underestimated severity levels**

| **Purpose** | Identify bugs whose severity could be underestimated. |
| ----------- | ------------------------------------------------------------- |
| **Action**  | Needinfo the assignee or the triage owner if not assigned yet |
| **Code**    | severity_underestimated.py                                    |

----

This script should request needinfo for bugs that have low severity (`S3` and `S4`) if one of the following exceed the configured threshold:

- [x] Duplicates
- [x] Votes
- [x] CCs
- [ ] #1322
- [ ] ~Comments from unique users~ ([Marco's reply](https://github.com/mozilla/relman-auto-nag/issues/1184#issuecomment-1066562736))

Also, a report with a list of bugs should be sent to configured recipients.

----

The following scripts are producing similar reports (separately):

- [`several_dups.py`](https://github.com/mozilla/relman-auto-nag/blob/4ac56ae2f84b423b04487b5b61af8d435d3fd37d/auto_nag/scripts/several_dups.py)
- [`lot_of_votes.py`](https://github.com/mozilla/relman-auto-nag/blob/c88363cda09bbeea91ce1c4a59ccac71b3865108/auto_nag/scripts/lot_of_votes.py)
- [`lot_of_cc.py`](https://github.com/mozilla/relman-auto-nag/blob/4ac56ae2f84b423b04487b5b61af8d435d3fd37d/auto_nag/scripts/lot_of_cc.py)

However, these scripts have the following differences with this one:

- They do not consider if a needinfo already been sent or not.
- They do not consider the current severity level.
