### PR TITLE
Generate short Bugzilla URLs

### DIFF
--- a/auto_nag/bzcleaner.py
+++ b/auto_nag/bzcleaner.py
@@ -563,7 +563,7 @@ class BzCleaner(object):
             )
             common = env.get_template("common.html")
             body = common.render(
-                message=message, query_url=utils.split_long_url(self.query_url)
+                message=message, query_url=utils.generate_short_bz_url(self.query_url)
             )
             return self.get_email_subject(date), body
         return None, None

--- a/auto_nag/bzcleaner.py
+++ b/auto_nag/bzcleaner.py
@@ -563,7 +563,7 @@ class BzCleaner(object):
             )
             common = env.get_template("common.html")
             body = common.render(
-                message=message, query_url=utils.generate_short_bz_url(self.query_url)
+                message=message, query_url=utils.shorten_long_bz_url(self.query_url)
             )
             return self.get_email_subject(date), body
         return None, None

--- a/auto_nag/nag_me.py
+++ b/auto_nag/nag_me.py
@@ -232,7 +232,7 @@ class Nag(object):
                 enumerate=enumerate,
                 data=self.organize_nag(data),
                 nag=True,
-                query_url_nag=utils.split_long_url(query_url),
+                query_url_nag=utils.generate_short_bz_url(query_url),
                 table_attrs=self.get_config("table_attrs"),
                 nag_preamble=self.nag_preamble(),
             )

--- a/auto_nag/utils.py
+++ b/auto_nag/utils.py
@@ -45,6 +45,8 @@ COL_PAT = re.compile(":[^:]*")
 BACKOUT_PAT = re.compile("^back(s|(ed))?[ \t]*out", re.I)
 BUG_PAT = re.compile(r"^bug[s]?[ \t]*([0-9]+)", re.I)
 
+MAX_URL_LENGTH = 512
+
 
 def get_weekdays():
     return {"Mon": 0, "Tue": 1, "Wed": 2, "Thu": 3, "Fri": 4, "Sat": 5, "Sun": 6}
@@ -159,7 +161,7 @@ def english_list(items):
 
 
 def generate_short_bz_url(url):
-    if not url:
+    if not url or len(url) <= MAX_URL_LENGTH:
         return url
 
     # the url can be very long and line length are limited in email protocol:

--- a/auto_nag/utils.py
+++ b/auto_nag/utils.py
@@ -18,7 +18,7 @@ from dateutil.relativedelta import relativedelta
 from libmozdata import release_calendar as rc
 from libmozdata import utils as lmdutils
 from libmozdata import versions as lmdversions
-from libmozdata.bugzilla import Bugzilla
+from libmozdata.bugzilla import Bugzilla, BugzillaShorten
 from libmozdata.hgmozilla import Mercurial
 
 try:
@@ -44,8 +44,6 @@ UTC_PAT = re.compile(r"UTC\+[^ \t]*")
 COL_PAT = re.compile(":[^:]*")
 BACKOUT_PAT = re.compile("^back(s|(ed))?[ \t]*out", re.I)
 BUG_PAT = re.compile(r"^bug[s]?[ \t]*([0-9]+)", re.I)
-
-MAX_URL_LENGTH = 512
 
 
 def get_weekdays():
@@ -160,20 +158,21 @@ def english_list(items):
     return "{} and {}".format(", ".join(items[:-1]), items[-1])
 
 
-def split_long_url(url):
+def generate_short_bz_url(url):
     if not url:
         return url
 
     # the url can be very long and line length are limited in email protocol:
     # https://datatracker.ietf.org/doc/html/rfc5322#section-2.1.1
-    # So we insert some \n in the url every MAX_URL_LENGTH characters.
-    # The limit of 78 chars is for the rendering and here the url will end up in a
-    # href so we don't care.
-    if len(url) > MAX_URL_LENGTH:
-        url = "\n".join(
-            [url[i : i + MAX_URL_LENGTH] for i in range(0, len(url), MAX_URL_LENGTH)]
-        )
-    return url
+    # So we need to generate a short URL.
+
+    def url_handler(u, data):
+        data["url"] = u
+
+    data = {}
+    BugzillaShorten(url, url_data=data, url_handler=url_handler).wait()
+
+    return data["url"]
 
 
 def search_prev_merge(beta):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ humanize>=0.5.1
 icalendar==4.0.9
 icalevents==0.1.24
 Jinja2==3.0.3
-libmozdata>=0.1.69
+libmozdata>=0.1.75
 numpy==1.21.5
 pep8==1.7.1
 pyflakes==2.4.0


### PR DESCRIPTION
This should fix #1324.

In this PR, we generate short URLs for all queries. Alternatively, we could generate the short URLs only when the length exceeds the threshold (i.e., 512).