### PR TITLE
Needinfo for bugs with high security keywords and low severity

### DIFF
--- a/auto_nag/scripts/severity_high_security.py
+++ b/auto_nag/scripts/severity_high_security.py
@@ -1,0 +1,69 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from auto_nag import utils
+from auto_nag.bzcleaner import BzCleaner
+
+HIGH_SECURITY_KEYWORDS = ["sec-high", "sec-critical"]
+
+
+class SeverityHighSecurity(BzCleaner):
+    def description(self):
+        return "Bugs with high security keywords whose set to low severity"
+
+    def has_needinfo(self):
+        return True
+
+    def handle_bug(self, bug, data):
+        security_keywords = [
+            keyword for keyword in bug["keywords"] if keyword in HIGH_SECURITY_KEYWORDS
+        ]
+        assert len(security_keywords) == 1
+        security_keyword = security_keywords[0]
+
+        bugid = str(bug["id"])
+        data[bugid] = {
+            "security_keyword": security_keyword,
+            "severity": bug["severity"],
+        }
+
+        return bug
+
+    def get_extra_for_needinfo_template(self):
+        return self.get_data()
+
+    def columns(self):
+        return ["id", "summary", "severity", "security_keyword"]
+
+    def get_mail_to_auto_ni(self, bug):
+        for field in ["assigned_to", "triage_owner"]:
+            person = bug.get(field, "")
+            if person and not utils.is_no_assignee(person):
+                return {"mail": person, "nickname": bug[f"{field}_detail"]["nick"]}
+
+        return None
+
+    def get_bz_params(self, date):
+        fields = ["triage_owner", "assigned_to", "severity", "keywords"]
+
+        params = {
+            "include_fields": fields,
+            "resolution": "---",
+            "f3": "keywords",
+            "o3": "anyexact",
+            "v3": HIGH_SECURITY_KEYWORDS,
+            "f4": "bug_severity",
+            "o4": "anyexact",
+            "v4": ["S3", "S4"],
+            "n15": 1,
+            "f15": "longdesc",
+            "o15": "casesubstring",
+            "v15": "could you consider increasing the severity of this security bug?",
+        }
+
+        return params
+
+
+if __name__ == "__main__":
+    SeverityHighSecurity().run()

--- a/auto_nag/scripts/severity_high_security.py
+++ b/auto_nag/scripts/severity_high_security.py
@@ -27,8 +27,12 @@ class SeverityHighSecurity(BzCleaner):
             "security_keyword": security_keyword,
             "severity": bug["severity"],
         }
+        self.extra_ni = data
 
         return bug
+
+    def get_extra_for_needinfo_template(self):
+        return self.extra_ni
 
     def columns(self):
         return ["id", "summary", "severity", "security_keyword"]

--- a/auto_nag/scripts/severity_high_security.py
+++ b/auto_nag/scripts/severity_high_security.py
@@ -27,12 +27,8 @@ class SeverityHighSecurity(BzCleaner):
             "security_keyword": security_keyword,
             "severity": bug["severity"],
         }
-        self.extra_ni = data
 
         return bug
-
-    def get_extra_for_needinfo_template(self):
-        return self.extra_ni
 
     def columns(self):
         return ["id", "summary", "severity", "security_keyword"]

--- a/auto_nag/scripts/severity_high_security.py
+++ b/auto_nag/scripts/severity_high_security.py
@@ -56,7 +56,7 @@ class SeverityHighSecurity(BzCleaner):
             "v3": HIGH_SECURITY_KEYWORDS,
             "f4": "bug_severity",
             "o4": "anyexact",
-            "v4": ["S3", "S4"],
+            "v4": ["S3", "normal", "S4", "minor", "trivial", "enhancement"],
             "n15": 1,
             "f15": "longdesc",
             "o15": "casesubstring",

--- a/auto_nag/scripts/severity_high_security.py
+++ b/auto_nag/scripts/severity_high_security.py
@@ -27,11 +27,12 @@ class SeverityHighSecurity(BzCleaner):
             "security_keyword": security_keyword,
             "severity": bug["severity"],
         }
+        self.extra_ni = data
 
         return bug
 
     def get_extra_for_needinfo_template(self):
-        return self.get_data()
+        return self.extra_ni
 
     def columns(self):
         return ["id", "summary", "severity", "security_keyword"]

--- a/auto_nag/scripts/severity_high_security.py
+++ b/auto_nag/scripts/severity_high_security.py
@@ -10,7 +10,7 @@ HIGH_SECURITY_KEYWORDS = ["sec-high", "sec-critical"]
 
 class SeverityHighSecurity(BzCleaner):
     def description(self):
-        return "Bugs with high security keywords whose set to low severity"
+        return "Bugs with high security keywords which are set to low severity"
 
     def has_needinfo(self):
         return True

--- a/runauto_nag_daily.sh
+++ b/runauto_nag_daily.sh
@@ -147,6 +147,9 @@ python -m auto_nag.scripts.severity_inconsistency --production
 # Needinfo for bugs with underestimated severity levels
 python -m auto_nag.scripts.severity_underestimated
 
+# Needinfo for bugs with high security keywords whose set to low severity
+python -m auto_nag.scripts.severity_underestimated
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m auto_nag.log --send

--- a/templates/severity_high_security.html
+++ b/templates/severity_high_security.html
@@ -1,0 +1,27 @@
+<p>The following {{ plural('bug has', data, pword='bugs have') }} discrepancy between the bug severity and the security keyword. {{ plural('Owner', data) }} got {{ plural('a needinfo request', data, pword='needinfo requests') }} to bump the severity:
+    <table {{ table_attrs }}>
+      <thead>
+        <tr>
+          <th>Bug</th><th>Summary</th><th>Severity</th><th>Security Keyword</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for i, (bugid, summary, severity, security_keyword) in enumerate(data) -%}
+        <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+          <td>
+            <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+           </td>
+          <td>
+            {{ summary | e }}
+          </td>
+          <td>
+            {{ severity }}
+          </td>
+          <td>
+            {{ security_keyword }}
+          </td>
+        </tr>
+        {% endfor -%}
+      </tbody>
+    </table>
+</p>

--- a/templates/severity_high_security_needinfo.txt
+++ b/templates/severity_high_security_needinfo.txt
@@ -1,0 +1,4 @@
+The severity field for this bug is set to {{ extra[bugid]["severity"] }}. However, the bug is flagged with the `{{ extra[bugid]["security_keyword"] }}` keyword.
+:{{ nickname }}, could you consider increasing the severity of this security bug?
+
+{{ documentation }}

--- a/templates/severity_high_security_needinfo.txt
+++ b/templates/severity_high_security_needinfo.txt
@@ -1,4 +1,4 @@
-The severity field for this bug is set to {{ severity }}. However, the bug is flagged with the `{{ security_keyword }}` keyword.
+The severity field for this bug is set to {{ extra[bugid]["severity"] }}. However, the bug is flagged with the `{{ extra[bugid]["security_keyword"] }}` keyword.
 :{{ nickname }}, could you consider increasing the severity of this security bug?
 
 {{ documentation }}

--- a/templates/severity_high_security_needinfo.txt
+++ b/templates/severity_high_security_needinfo.txt
@@ -1,4 +1,4 @@
-The severity field for this bug is set to {{ extra[bugid]["severity"] }}. However, the bug is flagged with the `{{ extra[bugid]["security_keyword"] }}` keyword.
+The severity field for this bug is set to {{ severity }}. However, the bug is flagged with the `{{ security_keyword }}` keyword.
 :{{ nickname }}, could you consider increasing the severity of this security bug?
 
 {{ documentation }}


### PR DESCRIPTION
This should resolve #1336.

I do not have access to security bugs. Thus I was not able to test the results. The following are needed:

- [x] Check the [query results](https://bugzilla.mozilla.org/buglist.cgi?include_fields=triage_owner&include_fields=assigned_to&include_fields=severity&include_fields=keywords&include_fields=id&include_fields=summary&include_fields=groups&include_fields=flags&resolution=---&f3=keywords&o3=anyexact&v3=sec-high&v3=sec-critical&f4=bug_severity&o4=anyexact&v4=S3&v4=S4&n15=1&f15=longdesc&o15=casesubstring&v15=could+you+consider+increasing+the+severity+of+this+security+bug%3F&f16=status_whiteboard&o16=notsubstring&v16=%5Bno-nag%5D&product=Core&product=DevTools&product=External+Software+Affecting+Firefox&product=Fenix&product=Firefox&product=Firefox+for+iOS&product=Firefox+Build+System&product=GeckoView&product=JSS&product=NSPR&product=NSS&product=Remote+Protocol&product=Testing&product=Toolkit&product=Web+Compatibility&product=WebExtensions).
- [x] Test the tool in the dry-run mode.

---

## Autonag wiki page

**Bugs with high security keywords which are set to low severity**

| **Purpose** | Identify bugs whose severity field is set to S3 or S4 and at the same time have sec-high or sec-critical keywords. |
| ----------- | :------------------------------------------------------------------------------------------------------------------ |
| **Action**  | Needinfo to propose increasing the severity.                                                                        |
| **Code**    | severity_high_security.py                                                                                           |
