### PR TITLE
Merge additional receivers with the common receivers

### DIFF
--- a/auto_nag/bzcleaner.py
+++ b/auto_nag/bzcleaner.py
@@ -217,19 +217,6 @@ class BzCleaner(object):
                 "bugids": [str(bugid)],
             }
 
-    def get_receivers(self):
-        receiver_lists = utils.get_config("common", "receiver_list", default={})
-
-        receivers = self.get_config("receivers")
-        if isinstance(receivers, six.string_types):
-            receivers = receiver_lists[receivers]
-
-        additional_receivers = self.get_config("additional_receivers")
-        if isinstance(additional_receivers, six.string_types):
-            additional_receivers = receiver_lists[additional_receivers]
-
-        return set([*receivers, *additional_receivers])
-
     def bughandler(self, bug, data):
         """bug handler for the Bugzilla query"""
         if bug["id"] in self.cache:
@@ -591,7 +578,7 @@ class BzCleaner(object):
         login_info = utils.get_login_info()
         title, body = self.get_email(date)
         if title:
-            receivers = self.get_receivers()
+            receivers = utils.get_receivers(self.name())
             status = "Success"
             try:
                 mail.send(

--- a/auto_nag/bzcleaner.py
+++ b/auto_nag/bzcleaner.py
@@ -218,12 +218,17 @@ class BzCleaner(object):
             }
 
     def get_receivers(self):
+        receiver_lists = utils.get_config("common", "receiver_list", default={})
+
         receivers = self.get_config("receivers")
         if isinstance(receivers, six.string_types):
-            receivers = utils.get_config("common", "receiver_list", default={})[
-                receivers
-            ]
-        return receivers
+            receivers = receiver_lists[receivers]
+
+        additional_receivers = self.get_config("additional_receivers")
+        if isinstance(additional_receivers, six.string_types):
+            additional_receivers = receiver_lists[additional_receivers]
+
+        return set([*receivers, *additional_receivers])
 
     def bughandler(self, bug, data):
         """bug handler for the Bugzilla query"""

--- a/auto_nag/erroneous_bzmail.py
+++ b/auto_nag/erroneous_bzmail.py
@@ -12,7 +12,7 @@ def send_mail(err, dryrun=False):
             "erroneous_bzmail_email.html",
             fb,
             "Triage owners with erroneous Bugzilla email",
-            Cc=utils.get_config("common", "receivers"),
+            Cc=utils.get_receivers("common"),
             dryrun=dryrun,
             bzmails=bzmails,
             plural=utils.plural,

--- a/auto_nag/next_release.py
+++ b/auto_nag/next_release.py
@@ -17,7 +17,7 @@ from . import logger, mail, utils
 def send_mail(next_date, bad_date_nrd, bad_date_ro, dryrun=False):
     mail.send_from_template(
         "next_release_email",
-        utils.get_config("next-release", "receivers"),
+        utils.get_receivers("next-release"),
         "Next release date is not up-to-date",
         dryrun=dryrun,
         next_date=next_date,

--- a/auto_nag/round_robin_fallback.py
+++ b/auto_nag/round_robin_fallback.py
@@ -14,7 +14,7 @@ def send_mail(nag, dryrun=False):
             "round_robin_fallback_email.html",
             fb,
             "Triage owners need to be updated",
-            Cc=utils.get_config("common", "receivers"),
+            Cc=utils.get_receivers("common"),
             dryrun=dryrun,
             calendars=calendars,
             plural=utils.plural,

--- a/auto_nag/utils.py
+++ b/auto_nag/utils.py
@@ -78,11 +78,11 @@ def get_receivers(tool_name):
     receiver_lists = get_config("common", "receiver_list", default={})
 
     receivers = get_config(tool_name, "receivers", [])
-    if isinstance(receivers, six.string_types):
+    if isinstance(receivers, str):
         receivers = receiver_lists[receivers]
 
     additional_receivers = get_config(tool_name, "additional_receivers", [])
-    if isinstance(additional_receivers, six.string_types):
+    if isinstance(additional_receivers, str):
         additional_receivers = receiver_lists[additional_receivers]
 
     return list(dict.fromkeys([*receivers, *additional_receivers]))

--- a/auto_nag/utils.py
+++ b/auto_nag/utils.py
@@ -74,6 +74,20 @@ def get_config(name, entry, default=None):
     return tool_conf.get(entry, default)
 
 
+def get_receivers(tool_name):
+    receiver_lists = get_config("common", "receiver_list", default={})
+
+    receivers = get_config(tool_name, "receivers", [])
+    if isinstance(receivers, six.string_types):
+        receivers = receiver_lists[receivers]
+
+    additional_receivers = get_config(tool_name, "additional_receivers", [])
+    if isinstance(additional_receivers, six.string_types):
+        additional_receivers = receiver_lists[additional_receivers]
+
+    return list(dict.fromkeys([*receivers, *additional_receivers]))
+
+
 def init_random():
     now = datetime.datetime.utcnow()
     now = now.timestamp()


### PR DESCRIPTION
With this PR, tools can declare `additional_receivers` in their configurations. The list of receivers in the `additional_receivers` field will be merged with the common receivers. If a tool declares the `receivers` field, it will replace the common receivers.