### PR TITLE
Fix black by updating to the lates version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/ambv/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8


### PR DESCRIPTION
A new version of `click` (v8.1.0). One of `black`'s dependencies introduced the following error in `pre-commit` (see https://github.com/psf/black/issues/2964):
```
seed isort known_third_party.............................................Passed
isort....................................................................Passed
black....................................................................Failed
- hook id: black
- exit code: 1

Traceback (most recent call last):
  File "/Users/smujahid/.cache/pre-commit/repopnfkm2uv/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/Users/smujahid/.cache/pre-commit/repopnfkm2uv/py_env-python3/lib/python3.9/site-packages/black/__init__.py", line 1423, in patched_main
    patch_click()
  File "/Users/smujahid/.cache/pre-commit/repopnfkm2uv/py_env-python3/lib/python3.9/site-packages/black/__init__.py", line 1409, in patch_click
    from click import _unicodefun
ImportError: cannot import name '_unicodefun' from 'click' (/Users/smujahid/.cache/pre-commit/repopnfkm2uv/py_env-python3/lib/python3.9/site-packages/click/__init__.py)

flake8...................................................................Passed
check python ast.........................................................Passed
check docstring is first.................................................Passed
check that executables have shebangs.................(no files to check)Skipped
check for merge conflicts................................................Passed
check for broken symlinks............................(no files to check)Skipped
debug statements (python)................................................Passed
trim trailing whitespace.................................................Passed
check yaml...........................................(no files to check)Skipped
mixed line ending........................................................Passed
tests should end in _test.py.........................(no files to check)Skipped
check json...........................................(no files to check)Skipped
fix requirements.txt.................................(no files to check)Skipped
check vcs permalinks.....................................................Passed
codespell................................................................Passed
taskcluster_yml......................................(no files to check)Skipped
Strip unnecessary `# noqa`s..............................................Passed
Check for useless excludes...........................(no files to check)Skipped
```

The issue got solved in the latest version of `black` (see https://github.com/psf/black/pull/2966).