### PR TITLE
Simplify the receiver lists

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -79,7 +79,7 @@
     ]
   },
   "missed_uplifts": {
-    "receivers": "rm"
+    "additional_receivers": "rm"
   },
   "has_str_no_range": {
     "days_lookup": 10,
@@ -187,7 +187,7 @@
     "days_lookup": 10
   },
   "next-release": {
-    "additional_receivers": ["release-mgmt@mozilla.com"]
+    "additional_receivers": "rm"
   },
   "escalation": {
     "high": {

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -22,7 +22,12 @@
     "database": "sqlite:///db/autonag.sqlite",
     "cache": "cache",
     "lock": "db/lock",
-    "receivers": ["calixte@mozilla.com", "sylvestre@mozilla.com"],
+    "receivers": [
+      "calixte@mozilla.com",
+      "sylvestre@mozilla.com",
+      "mcastelluccio@mozilla.com",
+      "smujahid@mozilla.com"
+    ],
     "on-errors": [
       "calixte@mozilla.com",
       "sylvestre@mozilla.com",
@@ -74,7 +79,7 @@
     ]
   },
   "missed_uplifts": {
-    "receivers": ["calixte@mozilla.com", "release-mgmt@mozilla.com"]
+    "receivers": "rm"
   },
   "has_str_no_range": {
     "days_lookup": 10,
@@ -92,11 +97,6 @@
   },
   "regression": {
     "max_days_in_cache": 7,
-    "receivers": [
-      "calixte@mozilla.com",
-      "sylvestre@mozilla.com",
-      "mcastelluccio@mozilla.com"
-    ],
     "days_lookup": 3,
     "resolution_skiplist": ["DUPLICATE", "INCOMPLETE", "INVALID"],
     "reporter_skiplist": ["wptsync@mozilla.bugs"],
@@ -127,8 +127,7 @@
   "assignee_no_login": {
     "unassign_weeks": 2,
     "number_of_months": 7,
-    "last_activity_months": 24,
-    "receivers": ["calixte@mozilla.com", "mcastelluccio@mozilla.com"]
+    "last_activity_months": 24
   },
   "not_landed": {
     "number_of_weeks": 2,
@@ -137,12 +136,7 @@
   "ni_from_manager": {
     "white-list": ["aoverholt@mozilla.com"],
     "days_lookup": 183,
-    "number_of_weeks": 1,
-    "receivers": [
-      "calixte@mozilla.com",
-      "sylvestre@mozilla.com",
-      "mcastelluccio@mozilla.com"
-    ]
+    "number_of_weeks": 1
   },
   "leave_open_no_activity": {
     "skiplist": ["sdeckelmann@mozilla.com"],
@@ -193,12 +187,7 @@
     "days_lookup": 10
   },
   "next-release": {
-    "receivers": [
-      "calixte@mozilla.com",
-      "sylvestre@mozilla.com",
-      "mcastelluccio@mozilla.com",
-      "release-mgmt@mozilla.com"
-    ]
+    "additional_receivers": ["release-mgmt@mozilla.com"]
   },
   "escalation": {
     "high": {
@@ -359,24 +348,14 @@
     "general_confidence_threshold": 0.8,
     "days_lookup": 365,
     "max_days_in_cache": 7,
-    "receivers": [
-      "calixte@mozilla.com",
-      "sylvestre@mozilla.com",
-      "mcastelluccio@mozilla.com"
-    ],
     "cc": []
   },
   "code_freeze_week": {
-    "receivers": ["calixte@mozilla.com", "release-mgmt@mozilla.com"],
+    "additional_receivers": "rm",
     "assignee_skiplist": ["wptsync@mozilla.bugs"]
   },
   "defectenhancementtask": {
     "max_days_in_cache": 7,
-    "receivers": [
-      "calixte@mozilla.com",
-      "sylvestre@mozilla.com",
-      "mcastelluccio@mozilla.com"
-    ],
     "days_lookup": 3,
     "reporter_skiplist": [
       "intermittent-bug-filer@mozilla.bugs",
@@ -399,28 +378,18 @@
   },
   "warn_regressed_by": {
     "max_days_in_cache": 7,
-    "receivers": ["calixte@mozilla.com", "release-mgmt@mozilla.com"]
+    "additional_receivers": "rm"
   },
   "regression_without_regressed_by": {
     "days_lookup": 30,
-    "reporter_skiplist": ["intermittent-bug-filer@mozilla.bugs"],
-    "receivers": [
-      "calixte@mozilla.com",
-      "sylvestre@mozilla.com",
-      "mcastelluccio@mozilla.com"
-    ]
+    "reporter_skiplist": ["intermittent-bug-filer@mozilla.bugs"]
   },
   "regressed_by_no_has_regression_range": {
     "days_lookup": 30
   },
   "prod_comp_changed_with_priority": {
     "days_lookup": 30,
-    "skiplist": ["nobody@mozilla.org", "bug-husbandry-bot@mozilla.bugs"],
-    "receivers": [
-      "calixte@mozilla.com",
-      "sylvestre@mozilla.com",
-      "mcastelluccio@mozilla.com"
-    ]
+    "skiplist": ["nobody@mozilla.org", "bug-husbandry-bot@mozilla.bugs"]
   },
   "to_triage": {
     "cc": [],
@@ -434,28 +403,17 @@
       }
     },
     "teams": ["DOM:LWS", "DOM:Core", "Core::General", "Media:audio"],
-    "persons": ["jdescottes@mozilla.com"],
-    "receivers": ["calixte@mozilla.com", "mcastelluccio@mozilla.com"]
+    "persons": ["jdescottes@mozilla.com"]
   },
   "spambug": {
     "max_days_in_cache": 7,
-    "receivers": [
-      "mcastelluccio@mozilla.com",
-      "sylvestre@mozilla.com",
-      "glob@mozilla.com",
-      "mhoye@mozilla.com"
-    ],
+    "additional_receivers": ["glob@mozilla.com", "mhoye@mozilla.com"],
     "days_lookup": 3,
     "confidence_threshold": 0.95,
     "cc": []
   },
   "stepstoreproduce": {
     "max_days_in_cache": 7,
-    "receivers": [
-      "calixte@mozilla.com",
-      "sylvestre@mozilla.com",
-      "mcastelluccio@mozilla.com"
-    ],
     "days_lookup": 3,
     "confidence_threshold": 0.9,
     "cc": [
@@ -466,11 +424,6 @@
   },
   "regressor": {
     "max_days_in_cache": 7,
-    "receivers": [
-      "calixte@mozilla.com",
-      "sylvestre@mozilla.com",
-      "mcastelluccio@mozilla.com"
-    ],
     "cc": [
       "sledru@mozilla.com",
       "mcastelluccio@mozilla.com",
@@ -487,31 +440,21 @@
       "sphink@gmail.com",
       "ttung@mozilla.com"
     ],
-    "receivers": [
-      "cdenizet@mozilla.com",
-      "sledru@mozilla.com",
-      "fbraun@mozilla.com",
-      "tritter@mozilla.com"
-    ]
+    "additional_receivers": ["fbraun@mozilla.com", "tritter@mozilla.com"]
   },
   "close_intermittents": {
     "sec": false
   },
   "uplift_beta": {
     "days_to_wait": 2,
-    "receivers": [
-      "calixte@mozilla.com",
-      "sylvestre@mozilla.com",
-      "mcastelluccio@mozilla.com",
-      "jcristau@mozilla.com"
-    ]
+    "additional_receivers": ["jcristau@mozilla.com"]
   },
   "regression_set_status_flags": {
     "receivers": ["jcristau@mozilla.com"],
     "component_exception": ["Testing::geckodriver"]
   },
   "fuzzing_bisection_without_regressed_by": {
-    "receivers": ["mcastelluccio@mozilla.com", "jkratzer@mozilla.com"],
+    "additional_receivers": ["jkratzer@mozilla.com"],
     "max_ni": 1
   },
   "good_first_bug_unassign_inactive": {


### PR DESCRIPTION
This PR depends on #1359.

I think there is more room for simplifications. I'm not sure if all tools should use `additional_receivers` instead of `receivers`. Examples:

https://github.com/mozilla/relman-auto-nag/blob/6ca57369d7b287286a00aaa97a841bfd43b59c59/auto_nag/scripts/configs/tools.json#L460-L462

https://github.com/mozilla/relman-auto-nag/blob/6ca57369d7b287286a00aaa97a841bfd43b59c59/auto_nag/scripts/configs/tools.json#L464-L465

https://github.com/mozilla/relman-auto-nag/blob/6ca57369d7b287286a00aaa97a841bfd43b59c59/auto_nag/scripts/configs/tools.json#L467-L468

