### PR TITLE
Use `.txt` extension for attached log files in emails

### DIFF
--- a/auto_nag/mail.py
+++ b/auto_nag/mail.py
@@ -6,7 +6,7 @@ import smtplib
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from os.path import basename, splitext
+from os.path import basename
 
 import six
 from jinja2 import Environment, FileSystemLoader
@@ -94,14 +94,11 @@ def send(
         Body = replaceUnicode(Body)
     message.attach(MIMEText(Body, subtype))
 
-    for file_path in files:
-        with open(file_path, "rb") as file:
-            name, ext = splitext(basename(file_path))
-            if ext == ".log":
-                ext = ".txt"
-            filename = name + ext
-            part = MIMEApplication(file.read(), Name=filename)
-            part["Content-Disposition"] = 'attachment; filename="%s"' % filename
+    for file in files:
+        with open(file, "rb") as In:
+            file = basename(file)
+            part = MIMEApplication(In.read(), Name=basename(file))
+            part["Content-Disposition"] = 'attachment; filename="%s"' % file
             message.attach(part)
 
     sendMail(From, To + Cc + Bcc, message.as_string(), login=login, dryrun=dryrun)

--- a/auto_nag/mail.py
+++ b/auto_nag/mail.py
@@ -6,7 +6,7 @@ import smtplib
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from os.path import basename
+from os.path import basename, splitext
 
 import six
 from jinja2 import Environment, FileSystemLoader
@@ -94,11 +94,14 @@ def send(
         Body = replaceUnicode(Body)
     message.attach(MIMEText(Body, subtype))
 
-    for file in files:
-        with open(file, "rb") as In:
-            file = basename(file)
-            part = MIMEApplication(In.read(), Name=basename(file))
-            part["Content-Disposition"] = 'attachment; filename="%s"' % file
+    for file_path in files:
+        with open(file_path, "rb") as file:
+            name, ext = splitext(basename(file_path))
+            if ext == ".log":
+                ext = ".txt"
+            filename = name + ext
+            part = MIMEApplication(file.read(), Name=filename)
+            part["Content-Disposition"] = 'attachment; filename="%s"' % filename
             message.attach(part)
 
     sendMail(From, To + Cc + Bcc, message.as_string(), login=login, dryrun=dryrun)

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -58,7 +58,7 @@
       "Web Compatibility",
       "WebExtensions"
     ],
-    "log": "/tmp/auto_nag_errors.log",
+    "log": "/tmp/auto_nag_errors.txt",
     "receiver_list": {
       "rm": ["calixte@mozilla.com", "release-mgmt@mozilla.com"]
     }


### PR DESCRIPTION
This will make it possible to preview the log files in Gmail without downloading them. Also, the content of the file will be searchable.