### PR TITLE
Add comment to bugs when receiving patches after being closed

### DIFF
--- a/auto_nag/bzcleaner.py
+++ b/auto_nag/bzcleaner.py
@@ -342,15 +342,29 @@ class BzCleaner(object):
 
         self.has_flags = "flags" in params.get("include_fields", [])
 
+    def has_attachments(self):
+        return False
+
+    def attachmenthandler(self, attachment, bugid, data):
+        raise Exception("Please implement the method in the inheriting class")
+
+    def get_attachment_include_fields(self):
+        return None
+
+    def get_bz_search_url(self, params):
+        return utils.get_bz_search_url(params)
+
     def get_bugs(self, date="today", bug_ids=[], chunk_size=None):
         """Get the bugs"""
         bugs = self.get_data()
         params = self.get_bz_params(date)
         self.amend_bzparams(params, bug_ids)
-        self.query_url = utils.get_bz_search_url(params)
+        self.query_url = self.get_bz_search_url(params)
 
         if isinstance(self, Nag):
             self.query_params = params
+
+        attachmenthandler = self.attachmenthandler if self.has_attachments() else None
 
         old_CHUNK_SIZE = Bugzilla.BUGZILLA_CHUNK_SIZE
         try:
@@ -361,6 +375,9 @@ class BzCleaner(object):
                 params,
                 bughandler=self.bughandler,
                 bugdata=bugs,
+                attachmenthandler=attachmenthandler,
+                attachmentdata=bugs,
+                attachment_include_fields=self.get_attachment_include_fields(),
                 timeout=self.get_config("bz_query_timeout"),
             ).get_data().wait()
         finally:

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -63,6 +63,15 @@
       "rm": ["calixte@mozilla.com", "release-mgmt@mozilla.com"]
     }
   },
+  "patch_closed_bug": {
+    "days_count": 5,
+    "receivers": [
+      "calixte@mozilla.com",
+      "sylvestre@mozilla.com",
+      "mcastelluccio@mozilla.com",
+      "smujahid@mozilla.com"
+    ]
+  },
   "has_str_no_hasstr": {
     "products": [
       "Core",

--- a/auto_nag/scripts/patch_closed_bug.py
+++ b/auto_nag/scripts/patch_closed_bug.py
@@ -1,0 +1,81 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from auto_nag import utils
+from auto_nag.bzcleaner import BzCleaner
+
+COMMENT_BODY = "A patch has been landed on this ticket, but it has already been closed. Filing a separate ticket will ensure better tracking. If this was not by mistake and further action is needed, please alert the appropriate party."
+
+
+class PatchClosedBug(BzCleaner):
+    def __init__(self):
+        super(PatchClosedBug, self).__init__()
+        self.days_count = self.get_config("days_count", 5)
+
+    def description(self):
+        return "Bugs with recent patches after being closed"
+
+    def columns(self):
+        return ["id", "summary", "resolved_at", "latest_patch_at"]
+
+    def handle_bug(self, bug, data):
+        bugid = str(bug["id"])
+        data[bugid] = {
+            "resolved_at": bug["cf_last_resolved"],
+        }
+        return bug
+
+    def has_attachments(self):
+        return True
+
+    def attachmenthandler(self, attachments, bugid, data):
+        latest_patch = max(
+            [
+                attachment["last_change_time"]
+                for attachment in attachments
+                if attachment["content_type"] == "text/x-phabricator-request"
+            ]
+        )
+
+        bug = data[bugid]
+        bug_resolved_at = bug["resolved_at"]
+        if latest_patch > bug_resolved_at:
+            bug["resolved_at"] = utils.get_human_lag(bug_resolved_at)
+            bug["latest_patch_at"] = utils.get_human_lag(latest_patch)
+        else:
+            del data[bugid]
+
+    def get_attachment_include_fields(self):
+        return ["content_type", "last_change_time"]
+
+    def get_bz_params(self, date):
+        fields = ["cf_last_resolved"]
+        params = {
+            "include_fields": fields,
+            "bug_status": ["RESOLVED", "VERIFIED"],
+            "f1": "bug_status",
+            "o1": "changedafter",
+            "v1": f"-{self.days_count}d",
+            "f2": "attachments.mimetype",
+            "o2": "equals",
+            "v2": "text/x-phabricator-request",
+            "n6": 1,
+            "f6": "longdesc",
+            "o6": "casesubstring",
+            "v6": COMMENT_BODY,
+        }
+
+        return params
+
+    def get_bz_search_url(self, params):
+        return None
+
+    def get_autofix_change(self):
+        return {
+            "comment": {"body": COMMENT_BODY},
+        }
+
+
+if __name__ == "__main__":
+    PatchClosedBug().run()

--- a/templates/patch_closed_bug.html
+++ b/templates/patch_closed_bug.html
@@ -1,0 +1,27 @@
+<p>The following {{ plural('bug', data) }} received {{ plural('a patch', data, pword="patches") }} after being closed:
+    <table {{ table_attrs }}>
+      <thead>
+        <tr>
+          <th>Bug</th><th>Summary</th><th>Resolution</th><th>Last patch</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for i, (bugid, summary, resolved_at, latest_patch_at) in enumerate(data) -%}
+        <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+          <td>
+            <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+          </td>
+          <td>
+            {{ summary | e }}
+          </td>
+          <td>
+            {{ resolved_at }}
+          </td>
+          <td>
+            {{ latest_patch_at }}
+          </td>
+        </tr>
+        {% endfor -%}
+      </tbody>
+    </table>
+  </p>


### PR DESCRIPTION
Resolves #1318 


## Autonag wiki page

**Bugs with patches after being closed**

| **Purpose** | Identify bugs that receive patches after being closed. |
| ----------- | :---------------------------------------------------- |
| **Action**  | Comment on the bug and email release managers.        |
| **Code**    | patch_closed_bug.py                                   |