### PR TITLE
Remove last activity limitation for unassigning inactive people from bugs

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -127,7 +127,8 @@
   "assignee_no_login": {
     "unassign_weeks": 2,
     "number_of_months": 7,
-    "last_activity_months": 24
+    "max_ni": 14,
+    "must_run": ["Mon"]
   },
   "not_landed": {
     "number_of_weeks": 2,


### PR DESCRIPTION
To avoid adding hundreds of needinfos to triage owners, run the script weekly and add a limit on the number of needinfos.

Fixes #266