### PR TITLE
For old bugs with low priority and low severity assigned to inactive people, unassign without needinfoing the triage owner

### DIFF
--- a/auto_nag/scripts/assignee_no_login.py
+++ b/auto_nag/scripts/assignee_no_login.py
@@ -11,6 +11,8 @@ from libmozdata import utils as lmdutils
 from auto_nag import people, utils
 from auto_nag.bzcleaner import BzCleaner
 
+THREE_YEARS_AGO = datetime.datetime.utcnow() - relativedelta(years=3)
+
 
 class AssigneeNoLogin(BzCleaner):
     def __init__(self):
@@ -74,7 +76,7 @@ class AssigneeNoLogin(BzCleaner):
             tzinfo=None
         )
         if (
-            last_change < datetime.datetime.utcnow() - relativedelta(years=3)
+            last_change < THREE_YEARS_AGO
             and bug["priority"] in ("P3", "P4", "P5")
             and bug["severity"]
             in ("S3", "normal", "S4", "minor", "trivial", "enhancement")


### PR DESCRIPTION
I'm not sure if we actually want to do this, maybe we can do it in case we get complaints about the tool.