### PR TITLE
Disable the security survey for now

### DIFF
--- a/auto_nag/scripts/survey_sec_bugs.py
+++ b/auto_nag/scripts/survey_sec_bugs.py
@@ -75,4 +75,5 @@ class SurveySecurityBugs(BzCleaner):
 
 
 if __name__ == "__main__":
-    SurveySecurityBugs().run()
+    return
+    # SurveySecurityBugs().run()


### PR DESCRIPTION
We are not making good use of the results we have and we can go through that data at any time.

(cc @mozfreddyb )