### PR TITLE
Adapt our new team name

### DIFF
--- a/auto_nag/scripts/configs/team_managers.json
+++ b/auto_nag/scripts/configs/team_managers.json
@@ -11,6 +11,7 @@
   "Security Engineering": "Christoph Kerschbaumer",
   "Javascript": "Steven De Tar",
   "Compiler and Development Tools": "Marco Castelluccio",
+  "CI and Quality Tools": "Marco Castelluccio",
   "OS Integration": "Gian-Carlo Pascutto",
   "GFX": "Bob Hood",
   "Internationalization": "Amir Habibi",


### PR DESCRIPTION
I kept the old name for now; we could drop it later. This will catch cases where the old name is still used (if any).