### PR TITLE
[vacant_triage_owner] Do not CC Release Management

### DIFF
--- a/auto_nag/scripts/vacant_triage_owner.py
+++ b/auto_nag/scripts/vacant_triage_owner.py
@@ -106,6 +106,9 @@ class TriageOwnerVacant(BzCleaner, Nag):
     def get_query_url_for_components(self, components):
         return None
 
+    def get_cc(self):
+        return set()
+
 
 if __name__ == "__main__":
     TriageOwnerVacant().run()


### PR DESCRIPTION
This will only avoid including Release Management in the CC. Managers will stay in the CC.