### PR TITLE
[severity_underestimated] Include `see_also_count`

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -175,6 +175,7 @@
     "number_dups": 3,
     "number_votes": 10,
     "number_cc": 50,
+    "number_see_also": 5,
     "additional_receivers": "rm",
     "must_run": ["Mon"]
   },

--- a/auto_nag/scripts/severity_underestimated.py
+++ b/auto_nag/scripts/severity_underestimated.py
@@ -9,10 +9,11 @@ from auto_nag.bzcleaner import BzCleaner
 class UnderestimatedSeverity(BzCleaner):
     def __init__(self):
         super(UnderestimatedSeverity, self).__init__()
-        self.nweeks = utils.get_config(self.name(), "weeks_lookup")
-        self.ndups = utils.get_config(self.name(), "number_dups")
-        self.votes = utils.get_config("lot_of_votes", "number_votes")
-        self.cc = utils.get_config("lot_of_cc", "number_cc")
+        self.nweeks = self.get_config("weeks_lookup")
+        self.ndups = self.get_config("number_dups")
+        self.votes = self.get_config("number_votes")
+        self.cc = self.get_config("number_cc")
+        self.see_also = self.get_config("number_see_also")
 
         self.extra_ni = {}
 
@@ -45,6 +46,7 @@ class UnderestimatedSeverity(BzCleaner):
             "dups_count",
             "votes",
             "cc_count",
+            "see_also_count",
         ]
 
     def get_extra_for_template(self):
@@ -52,6 +54,7 @@ class UnderestimatedSeverity(BzCleaner):
             "dups_threshold": self.ndups,
             "votes_threshold": self.votes,
             "cc_threshold": self.cc,
+            "see_also_threshold": self.see_also,
         }
 
     def handle_bug(self, bug, data):
@@ -59,6 +62,7 @@ class UnderestimatedSeverity(BzCleaner):
         cc_count = len(bug["cc"])
         dups_count = len(bug["duplicates"])
         votes_count = bug["votes"]
+        see_also_count = len(bug["see_also"])
 
         data[bugid] = {
             "creation": utils.get_human_lag(bug["creation_time"]),
@@ -67,6 +71,7 @@ class UnderestimatedSeverity(BzCleaner):
             "dups_count": dups_count,
             "votes": votes_count,
             "cc_count": cc_count,
+            "see_also_count": see_also_count,
         }
 
         factors = []
@@ -76,6 +81,8 @@ class UnderestimatedSeverity(BzCleaner):
             factors.append(f"{votes_count} votes")
         if cc_count >= self.cc:
             factors.append(f"{cc_count} CCs")
+        if see_also_count >= self.see_also:
+            factors.append(f"{see_also_count} See Also bugs")
 
         self.extra_ni[bugid] = {
             "severity": bug["severity"],
@@ -94,6 +101,7 @@ class UnderestimatedSeverity(BzCleaner):
             "votes",
             "cc",
             "duplicates",
+            "see_also",
         ]
 
         params = {
@@ -118,7 +126,10 @@ class UnderestimatedSeverity(BzCleaner):
             "f6": "cc_count",
             "o6": "greaterthaneq",
             "v6": self.cc,
-            "f7": "CP",
+            "f7": "see_also_count",
+            "o7": "greaterthaneq",
+            "v7": self.see_also,
+            "f8": "CP",
             "n15": 1,
             "f15": "longdesc",
             "o15": "casesubstring",

--- a/templates/severity_underestimated.html
+++ b/templates/severity_underestimated.html
@@ -10,10 +10,11 @@
         <th>Duplicates</th>
         <th>Votes</th>
         <th>CC</th>
+        <th>See Also</th>
       </tr>
     </thead>
     <tbody>
-      {% for i, (bugid, summary, creation, last_change, severity, dups_count, votes, cc_count) in enumerate(data) -%}
+      {% for i, (bugid, summary, creation, last_change, severity, dups_count, votes, cc_count, see_also_count) in enumerate(data) -%}
       <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
         <td>
           <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
@@ -38,6 +39,9 @@
         </td>
         <td {% if cc_count >= extra["cc_threshold"] %}bgcolor="#FFB8B8"{% endif -%}>
           {{ cc_count }}
+        </td>
+        <td {% if see_also_count >= extra["see_also_threshold"] %}bgcolor="#FFB8B8"{% endif -%}>
+          {{ see_also_count }}
         </td>
       </tr>
       {% endfor -%}


### PR DESCRIPTION
Resolves #1322

## Dry-run

<body>
<p>Hi there,</p>

<p>The following bugs have potential higher severity:
<table style="border:1px solid black;border-collapse:collapse;" border="1">
<thead>
    <tr>
    <th>Bug</th>
    <th>Summary</th>
    <th>Creation</th>
    <th>Last comment</th>
    <th>Severity</th>
    <th>Duplicates</th>
    <th>Votes</th>
    <th>CC</th>
    <th>See Also</th>
    </tr>
</thead>
<tbody>
    <tr bgcolor="#E0E0E0">
    <td>
        <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1762224">1762224</a>
    </td>
    <td>
        Background scripts without extension API calls are not correctly detected in ext-backgroundPage.js
    </td>
    <td>
        7 days
    </td>
    <td>
        2 days
    </td>
    <td>
        S3
    </td>
    <td >
        0
    </td>
    <td >
        0
    </td>
    <td >
        3
    </td>
    <td bgcolor="#FFB8B8">
        5
    </td>
    </tr>
    <tr >
    <td>
        <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1751159">1751159</a>
    </td>
    <td>
        [aliexpress] Aliexpress auto-fill address fields does not work
    </td>
    <td>
        2 months
    </td>
    <td>
        2 days
    </td>
    <td>
        S3
    </td>
    <td >
        0
    </td>
    <td >
        0
    </td>
    <td >
        5
    </td>
    <td bgcolor="#FFB8B8">
        5
    </td>
    </tr>
    <tr bgcolor="#E0E0E0">
    <td>
        <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1705430">1705430</a>
    </td>
    <td>
        Crash in [@ OOM | large | mozalloc_abort | webrender::renderer::Renderer::update_texture_cache]
    </td>
    <td>
        11 months
    </td>
    <td>
        6 days
    </td>
    <td>
        S4
    </td>
    <td >
        0
    </td>
    <td >
        3
    </td>
    <td >
        11
    </td>
    <td bgcolor="#FFB8B8">
        5
    </td>
    </tr>
    <tr >
    <td>
        <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1659439">1659439</a>
    </td>
    <td>
        Assertion failure in FocusState::IsCurrent MOZ_ASSERT(mLastContentProcessedEvent &lt;= mLastAPZProcessedEvent)
    </td>
    <td>
        1 year, 7 months
    </td>
    <td>
        13 days
    </td>
    <td>
        S3
    </td>
    <td >
        0
    </td>
    <td >
        0
    </td>
    <td >
        4
    </td>
    <td bgcolor="#FFB8B8">
        5
    </td>
    </tr>
    <tr bgcolor="#E0E0E0">
    <td>
        <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1609129">1609129</a>
    </td>
    <td>
        Line of white pixels on the left, bottom and right of a maximized window on secondary monitor
    </td>
    <td>
        2 years
    </td>
    <td>
        5 days
    </td>
    <td>
        S4
    </td>
    <td >
        1
    </td>
    <td >
        0
    </td>
    <td >
        21
    </td>
    <td bgcolor="#FFB8B8">
        5
    </td>
    </tr>
    <tr >
    <td>
        <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=702925">702925</a>
    </td>
    <td>
        &#34;Forget About This Site&#34; shouldn&#39;t delete saved passwords (without a prompt?)
    </td>
    <td>
        10 years
    </td>
    <td>
        2 days
    </td>
    <td>
        S3
    </td>
    <td bgcolor="#FFB8B8">
        5
    </td>
    <td >
        1
    </td>
    <td >
        27
    </td>
    <td >
        0
    </td>
    </tr>
    <tr bgcolor="#E0E0E0">
    <td>
        <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=144000">144000</a>
    </td>
    <td>
        Caret browsing is not available if there is no selection ranges
    </td>
    <td>
        19 years
    </td>
    <td>
        3 hours
    </td>
    <td>
        S3
    </td>
    <td bgcolor="#FFB8B8">
        3
    </td>
    <td >
        8
    </td>
    <td >
        30
    </td>
    <td >
        0
    </td>
    </tr>
    </tbody>
</table>
</p>
<p>Sincerely,<br>
    Release Management Bot
</p>
<p>
    See the search query on <a href="https://mzl.la/3KqM4u8">Bugzilla</a>.
</p>

<p>
    See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
</p>
</body>