### PR TITLE
Confirm bugs with crash signatures

### DIFF
--- a/auto_nag/scripts/crash_signature_confirm.py
+++ b/auto_nag/scripts/crash_signature_confirm.py
@@ -1,0 +1,31 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from auto_nag.bzcleaner import BzCleaner
+
+
+class CrashSignatureConfirm(BzCleaner):
+    def description(self):
+        return "Uncomforted bugs that have a crash signature"
+
+    def get_bz_params(self, date):
+        params = {
+            "bug_status": "UNCONFIRMED",
+            "f1": "cf_crash_signature",
+            "o1": "isnotempty",
+        }
+
+        return params
+
+    def get_autofix_change(self):
+        return {
+            "comment": {
+                "body": "The bug has a crash signature, thus the bug will be considered confirmed."
+            },
+            "status": "NEW",
+        }
+
+
+if __name__ == "__main__":
+    CrashSignatureConfirm().run()

--- a/auto_nag/scripts/crash_signature_confirm.py
+++ b/auto_nag/scripts/crash_signature_confirm.py
@@ -7,7 +7,7 @@ from auto_nag.bzcleaner import BzCleaner
 
 class CrashSignatureConfirm(BzCleaner):
     def description(self):
-        return "Uncomforted bugs that have a crash signature"
+        return "Unconfirmed bugs that have a crash signature"
 
     def get_bz_params(self, date):
         params = {

--- a/runauto_nag_daily.sh
+++ b/runauto_nag_daily.sh
@@ -153,6 +153,9 @@ python -m auto_nag.scripts.severity_high_security --production
 # Nag for components that need triage owner to be assigned
 python -m auto_nag.scripts.vacant_triage_owner --production
 
+# Confirm bugs with crash signatures
+python -m auto_nag.scripts.crash_signature_confirm --production
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m auto_nag.log --send

--- a/templates/crash_signature_confirm.html
+++ b/templates/crash_signature_confirm.html
@@ -1,0 +1,21 @@
+<p>The following {{ plural('bug has', data, pword='bugs have') }} crash {{ plural('signature', data) }} but {{ plural('its', data, pword='their') }} status was "UNCONFIRMED". The bot changed the status to "NEW":
+    <table {{ table_attrs }}>
+      <thead>
+        <tr>
+          <th>Bug</th><th>Summary</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for i, (bugid, summary) in enumerate(data) -%}
+        <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+          <td>
+            <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+          </td>
+          <td>
+            {{ summary | e }}
+          </td>
+        </tr>
+        {% endfor -%}
+      </tbody>
+    </table>
+  </p>


### PR DESCRIPTION
Resolves #1238 

## Autonag wiki page

**Automatically confirm bugs that have a crash signature**

| **Purpose** | Fix inconsistency in the status of unconfirmed bugs               |
| ----------- | :----------------------------------------------------------------- |
| **Action**  | Confirm bugs with crash signatures by changing the status to "NEW" |
| **Code**    | crash_signature_confirm.py                                         |
