### PR TITLE
Automatically confirm bugs that have an affected Firefox version flag

### DIFF
--- a/auto_nag/scripts/affected_flag_confirm.py
+++ b/auto_nag/scripts/affected_flag_confirm.py
@@ -17,13 +17,25 @@ class AffectedFlagConfirm(BzCleaner):
             "f1": "OP",
         }
 
+        statuses = ",".join(
+            [
+                "affected",
+                "wontfix",
+                "fix-optional",
+                "fixed",
+                "disabled",
+                "verified",
+                "verified disabled",
+            ]
+        )
+
         last_version = utils.get_nightly_version_from_bz()
         first_version = last_version - 40
         for version in range(first_version, last_version + 1):
             i = version - first_version + 2
             params[f"f{i}"] = f"cf_status_firefox{version}"
             params[f"o{i}"] = "anyexact"
-            params[f"v{i}"] = "affected,wontfix,fix-optional,fixed,disabled"
+            params[f"v{i}"] = statuses
         params[f"f{i+1}"] = "CP"
 
         return params

--- a/auto_nag/scripts/affected_flag_confirm.py
+++ b/auto_nag/scripts/affected_flag_confirm.py
@@ -2,16 +2,66 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
+from libmozdata.bugzilla import Bugzilla
+
 from auto_nag import utils
 from auto_nag.bzcleaner import BzCleaner
+
+VERSION_PREFIX = "cf_status_firefox"
+N = len(VERSION_PREFIX)
 
 
 class AffectedFlagConfirm(BzCleaner):
     def description(self):
         return "Unconfirmed bugs that have an affected Firefox version flag"
 
+    def handle_bug(self, bug, data):
+        bugid = str(bug["id"])
+        data[bugid] = {"creator": bug["creator"]}
+        return bug
+
+    def get_bugs(self, *args, **kwargs):
+        bugs = super().get_bugs(*args, **kwargs)
+        self.query_url = None
+
+        def history_handler(bug, data):
+            bugid = str(bug["id"])
+            creator = data[bugid]["creator"]
+            removed_status = set()
+            for event in reversed(bug["history"]):
+                for change in event["changes"]:
+                    if (
+                        change["field_name"].startswith(VERSION_PREFIX)
+                        and change["field_name"] not in removed_status
+                    ):
+                        if change["added"] == "affected":
+                            if event["who"] != creator:
+                                affected_version = True
+                                break
+                        elif change["removed"] == "affected":
+                            removed_status.add(change["field_name"])
+                else:
+                    affected_version = False
+
+                if affected_version:
+                    break
+            else:
+                del data[bugid]
+
+        Bugzilla(
+            list(bugs.keys()),
+            historyhandler=history_handler,
+            historydata=bugs,
+            timeout=960,
+        ).get_data().wait()
+
+        return bugs
+
     def get_bz_params(self, date):
+        fields = ["creator"]
         params = {
+            "include_fields": fields,
             "bug_status": "UNCONFIRMED",
             "j1": "OR",
             "f1": "OP",

--- a/auto_nag/scripts/affected_flag_confirm.py
+++ b/auto_nag/scripts/affected_flag_confirm.py
@@ -22,8 +22,8 @@ class AffectedFlagConfirm(BzCleaner):
         for version in range(first_version, last_version + 1):
             i = version - first_version + 2
             params[f"f{i}"] = f"cf_status_firefox{version}"
-            params[f"o{i}"] = "equals"
-            params[f"v{i}"] = "affected"
+            params[f"o{i}"] = "anyexact"
+            params[f"v{i}"] = "affected,wontfix,fix-optional,fixed,disabled"
         params[f"f{i+1}"] = "CP"
 
         return params
@@ -31,7 +31,7 @@ class AffectedFlagConfirm(BzCleaner):
     def get_autofix_change(self):
         return {
             "comment": {
-                "body": "The bug has an affected Firefox version flag, thus the bug will be considered confirmed."
+                "body": "The bug has a release status flag, thus it will be considered confirmed."
             },
             "status": "NEW",
         }

--- a/auto_nag/scripts/affected_flag_confirm.py
+++ b/auto_nag/scripts/affected_flag_confirm.py
@@ -2,66 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
-from libmozdata.bugzilla import Bugzilla
-
 from auto_nag import utils
 from auto_nag.bzcleaner import BzCleaner
-
-VERSION_PREFIX = "cf_status_firefox"
-N = len(VERSION_PREFIX)
 
 
 class AffectedFlagConfirm(BzCleaner):
     def description(self):
         return "Unconfirmed bugs that have an affected Firefox version flag"
 
-    def handle_bug(self, bug, data):
-        bugid = str(bug["id"])
-        data[bugid] = {"creator": bug["creator"]}
-        return bug
-
-    def get_bugs(self, *args, **kwargs):
-        bugs = super().get_bugs(*args, **kwargs)
-        self.query_url = None
-
-        def history_handler(bug, data):
-
-            bugid = str(bug["id"])
-            creator = data[bugid]["creator"]
-            removed_status = set()
-            for event in reversed(bug["history"]):
-
-                affected_version = ""
-                for change in event["changes"]:
-                    if (
-                        change["field_name"].startswith(VERSION_PREFIX)
-                        and change["field_name"] not in removed_status
-                    ):
-                        if change["added"] == "affected":
-                            if event["who"] != creator:
-                                affected_version = change["field_name"][N:]
-                                break
-                        elif change["removed"] == "affected":
-                            removed_status.add(change["field_name"])
-
-                if affected_version:
-                    data[bugid]["affected_version"] = affected_version
-                    break
-
-        Bugzilla(
-            list(bugs.keys()),
-            historyhandler=history_handler,
-            historydata=bugs,
-            timeout=960,
-        ).get_data().wait()
-
-        return {bugid: bug for bugid, bug in bugs.items() if "affected_version" in bug}
-
     def get_bz_params(self, date):
-        fields = ["creator"]
         params = {
-            "include_fields": fields,
             "bug_status": "UNCONFIRMED",
             "j1": "OR",
             "f1": "OP",

--- a/auto_nag/scripts/affected_flag_confirm.py
+++ b/auto_nag/scripts/affected_flag_confirm.py
@@ -1,0 +1,91 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+from libmozdata.bugzilla import Bugzilla
+
+from auto_nag import utils
+from auto_nag.bzcleaner import BzCleaner
+
+VERSION_PREFIX = "cf_status_firefox"
+N = len(VERSION_PREFIX)
+
+
+class AffectedFlagConfirm(BzCleaner):
+    def description(self):
+        return "Unconfirmed bugs that have an affected Firefox version flag"
+
+    def handle_bug(self, bug, data):
+        bugid = str(bug["id"])
+        data[bugid] = {"creator": bug["creator"]}
+        return bug
+
+    def get_bugs(self, *args, **kwargs):
+        bugs = super().get_bugs(*args, **kwargs)
+        self.query_url = None
+
+        def history_handler(bug, data):
+
+            bugid = str(bug["id"])
+            creator = data[bugid]["creator"]
+            removed_status = set()
+            for event in reversed(bug["history"]):
+
+                affected_version = ""
+                for change in event["changes"]:
+                    if (
+                        change["field_name"].startswith(VERSION_PREFIX)
+                        and change["field_name"] not in removed_status
+                    ):
+                        if change["added"] == "affected":
+                            if event["who"] != creator:
+                                affected_version = change["field_name"][N:]
+                                break
+                        elif change["removed"] == "affected":
+                            removed_status.add(change["field_name"])
+
+                if affected_version:
+                    data[bugid]["affected_version"] = affected_version
+                    break
+
+        Bugzilla(
+            list(bugs.keys()),
+            historyhandler=history_handler,
+            historydata=bugs,
+            timeout=960,
+        ).get_data().wait()
+
+        return {bugid: bug for bugid, bug in bugs.items() if "affected_version" in bug}
+
+    def get_bz_params(self, date):
+        fields = ["creator"]
+        params = {
+            "include_fields": fields,
+            "bug_status": "UNCONFIRMED",
+            "j1": "OR",
+            "f1": "OP",
+        }
+
+        last_version = utils.get_nightly_version_from_bz()
+        first_version = last_version - 40
+        for version in range(first_version, last_version + 1):
+            i = version - first_version + 2
+            params[f"f{i}"] = f"cf_status_firefox{version}"
+            params[f"o{i}"] = "equals"
+            params[f"v{i}"] = "affected"
+        params[f"f{i+1}"] = "CP"
+
+        return params
+
+    def get_autofix_change(self):
+        return {
+            "comment": {
+                "body": "The bug has an affected Firefox version flag, thus the bug will be considered confirmed."
+            },
+            "status": "NEW",
+        }
+
+
+if __name__ == "__main__":
+    AffectedFlagConfirm().run()

--- a/auto_nag/scripts/affected_flag_confirm.py
+++ b/auto_nag/scripts/affected_flag_confirm.py
@@ -2,66 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
-from libmozdata.bugzilla import Bugzilla
-
 from auto_nag import utils
 from auto_nag.bzcleaner import BzCleaner
-
-VERSION_PREFIX = "cf_status_firefox"
-N = len(VERSION_PREFIX)
 
 
 class AffectedFlagConfirm(BzCleaner):
     def description(self):
         return "Unconfirmed bugs that have an affected Firefox version flag"
 
-    def handle_bug(self, bug, data):
-        bugid = str(bug["id"])
-        data[bugid] = {"creator": bug["creator"]}
-        return bug
-
-    def get_bugs(self, *args, **kwargs):
-        bugs = super().get_bugs(*args, **kwargs)
-        self.query_url = None
-
-        def history_handler(bug, data):
-            bugid = str(bug["id"])
-            creator = data[bugid]["creator"]
-            removed_status = set()
-            for event in reversed(bug["history"]):
-                for change in event["changes"]:
-                    if (
-                        change["field_name"].startswith(VERSION_PREFIX)
-                        and change["field_name"] not in removed_status
-                    ):
-                        if change["added"] == "affected":
-                            if event["who"] != creator:
-                                affected_version = True
-                                break
-                        elif change["removed"] == "affected":
-                            removed_status.add(change["field_name"])
-                else:
-                    affected_version = False
-
-                if affected_version:
-                    break
-            else:
-                del data[bugid]
-
-        Bugzilla(
-            list(bugs.keys()),
-            historyhandler=history_handler,
-            historydata=bugs,
-            timeout=960,
-        ).get_data().wait()
-
-        return bugs
-
     def get_bz_params(self, date):
-        fields = ["creator"]
         params = {
-            "include_fields": fields,
             "bug_status": "UNCONFIRMED",
             "j1": "OR",
             "f1": "OP",

--- a/auto_nag/scripts/affected_flag_confirm.py
+++ b/auto_nag/scripts/affected_flag_confirm.py
@@ -43,7 +43,7 @@ class AffectedFlagConfirm(BzCleaner):
     def get_autofix_change(self):
         return {
             "comment": {
-                "body": "The bug has a release status flag, thus it will be considered confirmed."
+                "body": "The bug has a release status flag that shows some version of Firefox is affected, thus it will be considered confirmed."
             },
             "status": "NEW",
         }

--- a/runauto_nag_daily.sh
+++ b/runauto_nag_daily.sh
@@ -156,6 +156,9 @@ python -m auto_nag.scripts.vacant_triage_owner --production
 # Bugs with patches after being closed
 python -m auto_nag.scripts.patch_closed_bug --production
 
+# Confirm bugs with affected flags
+python -m auto_nag.scripts.affected_flag_confirm --production
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m auto_nag.log --send

--- a/templates/affected_flag_confirm.html
+++ b/templates/affected_flag_confirm.html
@@ -1,0 +1,21 @@
+<p>The following {{ plural('bug has', data, pword='bugs have') }} an affected Firefox version {{ plural('flag', data) }} but {{ plural('its', data, pword='their') }} status was "UNCONFIRMED". The bot changed the status to "NEW":
+    <table {{ table_attrs }}>
+      <thead>
+        <tr>
+          <th>Bug</th><th>Summary</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for i, (bugid, summary) in enumerate(data) -%}
+        <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+          <td>
+            <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+          </td>
+          <td>
+            {{ summary | e }}
+          </td>
+        </tr>
+        {% endfor -%}
+      </tbody>
+    </table>
+  </p>


### PR DESCRIPTION
Resolves #270 

We consider here the affected Firefox version flags for the **latest 41 versions**.

## Autonag wiki page

**Automatically confirm bugs that have an affected Firefox version flag**

| **Purpose** | Fix inconsistency in the status of unconfirmed bugs.                             |
| ----------- | :------------------------------------------------------------------------------- |
| **Action**  | Confirm bugs with affected Firefox version flags by changing the status to "NEW" |
| **Code**    | affected_flag_confirm.py                                                         |

## Dry-run

Finished within ~13 seconds. The results include 179 bugs.

```log
2022-04-12 17:04:19,013 - INFO - Run tool affected_flag_confirm.py
2022-04-12 17:04:32,220 - INFO - Tool affected_flag_confirm.py has finished.
```


