### PR TITLE
[assignee_no_login] Pull up the action limitation behaviour

### DIFF
--- a/auto_nag/scripts/assignee_no_login.py
+++ b/auto_nag/scripts/assignee_no_login.py
@@ -20,10 +20,7 @@ class AssigneeNoLogin(BzCleaner):
         self.unassign_weeks = utils.get_config(self.name(), "unassign_weeks", 2)
         self.nmonths = utils.get_config(self.name(), "number_of_months", 12)
         self.max_ni = utils.get_config(self.name(), "max_ni")
-        self.max_unassign_per_triage_owner = utils.get_config(
-            self.name(), "max_unassign_per_triage_owner"
-        )
-        self.autofix_assignee = {}
+        self.max_actions = utils.get_config(self.name(), "max_actions")
         self.default_assignees = utils.get_default_assignees()
         self.people = people.People.get_instance()
         self.unassign_count = collections.defaultdict(int)
@@ -53,67 +50,52 @@ class AssigneeNoLogin(BzCleaner):
     def get_max_ni(self):
         return self.max_ni
 
+    def get_max_actions(self):
+        return self.max_actions
+
     def handle_bug(self, bug, data):
         assignee = bug["assigned_to"]
         if self.people.is_mozilla(assignee):
             return None
 
-        bugid = str(bug["id"])
-
-        # Avoid to ni everyday...
-        if self.has_bot_set_ni(bug):
-            do_needinfo = False
+        prod = bug["product"]
+        comp = bug["component"]
+        default_assignee = self.default_assignees[prod][comp]
+        autofix = {"assigned_to": default_assignee}
 
         # Avoid to ni if the bug has low priority and low severity.
         # It's not paramount for triage owners to make an explicit decision here, it's enough for them
         # to receive the notification about the unassignment from Bugzilla via email.
-        elif (
+        if (
             bug["priority"] not in HIGH_PRIORITY
             and bug["severity"] not in HIGH_SEVERITY
         ):
-            do_needinfo = False
-
+            needinfo = None
+            autofix["comment"] = {
+                "body": f"The bug assignee didn't login in Bugzilla in the last { self.nmonths } months, so the assignee is being reset."
+            }
         else:
-            do_needinfo = True
-
-        if do_needinfo:
-            if not self.add_auto_ni(
-                bugid,
-                {
-                    "mail": bug["triage_owner"],
-                    "nickname": bug["triage_owner_detail"]["nick"],
-                },
-            ):
-                # Don't unassign if we can't needinfo.
-                return None
-        else:
-            if (
-                self.unassign_count[bug["triage_owner"]]
-                >= self.max_unassign_per_triage_owner
-            ):
-                return None
-            self.unassign_count[bug["triage_owner"]] += 1
-
-        data[bugid] = {"triage_owner": bug["triage_owner_detail"]["real_name"]}
-        prod = bug["product"]
-        comp = bug["component"]
-        default_assignee = self.default_assignees[prod][comp]
-        self.autofix_assignee[bugid] = {"assigned_to": default_assignee}
-        if do_needinfo:
             reason = []
             if bug["priority"] in HIGH_PRIORITY:
                 reason.append("priority '{}'".format(bug["priority"]))
             if bug["severity"] in HIGH_SEVERITY:
                 reason.append("severity '{}'".format(bug["severity"]))
-            self.extra_ni[bugid] = {
-                "reason": "/".join(reason),
-            }
-        else:
-            self.autofix_assignee[bugid]["comment"] = {
-                "body": f"The bug assignee didn't login in Bugzilla in the last { self.nmonths } months, so the assignee is being reset."
+
+            needinfo = {
+                "mail": bug["triage_owner"],
+                "nickname": bug["triage_owner_detail"]["nick"],
+                "extra": {"reason": "/".join(reason)},
             }
 
+        self.add_prioritized_action(bug, bug["triage_owner"], needinfo, autofix)
+
+        bugid = str(bug["id"])
+        data[bugid] = {"triage_owner": bug["triage_owner_detail"]["real_name"]}
+
         return bug
+
+    def get_sort_action_key(self, *args, **kwargs):
+        return utils.sort_bugs_by_importance(*args, **kwargs)
 
     def get_bz_params(self, date):
         date = lmdutils.get_date_ymd(date)
@@ -140,9 +122,6 @@ class AssigneeNoLogin(BzCleaner):
         utils.get_empty_assignees(params, negation=True)
 
         return params
-
-    def get_autofix_change(self):
-        return self.autofix_assignee
 
 
 if __name__ == "__main__":

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -132,7 +132,7 @@
     "unassign_weeks": 2,
     "number_of_months": 7,
     "max_ni": 7,
-    "max_unassign_per_triage_owner": 7,
+    "max_actions": 10,
     "must_run": ["Mon"]
   },
   "not_landed": {

--- a/auto_nag/utils.py
+++ b/auto_nag/utils.py
@@ -37,6 +37,16 @@ _CURRENT_VERSIONS = None
 _CONFIG_PATH = "./auto_nag/scripts/configs/"
 
 
+OLD_SEVERITY_MAP = {
+    "critical": "S1",
+    "major": "S2",
+    "normal": "S3",
+    "minor": "S4",
+    "trivial": "S4",
+    "enhancement": "S4",
+}
+
+
 BZ_FIELD_PAT = re.compile(r"^[fovj]([0-9]+)$")
 PAR_PAT = re.compile(r"\([^\)]*\)")
 BRA_PAT = re.compile(r"\[[^\]]*\]")
@@ -609,3 +619,14 @@ def get_nightly_version_from_bz():
 
 def nice_round(val):
     return int(round(100 * val))
+
+
+def sort_bugs_by_importance(action, bug):
+    has_needinfo = not action["needinfo"]
+    priority = bug["priority"] if bug["priority"].startswith("P") else "P10"
+    severity = (
+        bug["severity"]
+        if bug["severity"].startswith("S")
+        else OLD_SEVERITY_MAP.get(bug["severity"], "S10")
+    )
+    return (has_needinfo, priority, severity)


### PR DESCRIPTION
This PR will unblock https://github.com/mozilla/relman-auto-nag/pull/1396#issuecomment-1094854757; also, it can be used by other tools as suggested by @marco-c.

To limit the number of actions, we use two thresholds:
- `max_ni`: count for actions that end up adding needinfo only.
- `max_actions`: all actions including the ones that add needinfo.

When adding an action using `add_prioritized_action()`, the action can include both needinfo and/or auto-fix. The auto-fix will not be considered if a needinfo was provided but not added (e.g., exceed `max_ni`).

Before cutting out the bugs for exceeding the limit, the bugs will be sorted based on the result of `get_sort_action_key()`. As suggested by @marco-c , this method will be overridden by the tools to customize the prioritizations. 