### PR TITLE
Suggest increasing the severity for tracked bugs

### DIFF
--- a/auto_nag/scripts/severity_tracked.py
+++ b/auto_nag/scripts/severity_tracked.py
@@ -1,0 +1,99 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from auto_nag import utils
+from auto_nag.bzcleaner import BzCleaner
+
+# TODO: should be moved when resolving https://github.com/mozilla/relman-auto-nag/issues/1384
+LOW_SEVERITY = ["S3", "normal", "S4", "minor", "trivial", "enhancement"]
+
+
+class SeverityTracked(BzCleaner):
+    def __init__(self):
+        super(SeverityTracked, self).__init__()
+        if not self.init_versions():
+            return
+
+        self.nightly = self.versions["central"]
+        self.beta = self.versions["beta"]
+        self.release = self.versions["release"]
+        self.tracking_nightly = utils.get_flag(self.nightly, "tracking", "central")
+        self.tracking_beta = utils.get_flag(self.beta, "tracking", "beta")
+        self.tracking_release = utils.get_flag(self.release, "tracking", "release")
+        self.flags_map = {
+            self.tracking_nightly: f"firefox{self.nightly} (nightly)",
+            self.tracking_beta: f"firefox{self.beta} (beta)",
+            self.tracking_release: f"firefox{self.release} (release)",
+        }
+
+    def description(self):
+        return "Bugs with low severity that are marked as blocking or is tracked by release managers"
+
+    def handle_bug(self, bug, data):
+        bugid = str(bug["id"])
+        reasons = [
+            ("tracked for " if bug[flag] == "+" else "blocking ") + self.flags_map[flag]
+            for flag in self.flags_map.keys()
+            if flag in bug and bug[flag] in ["blocking", "+"]
+        ]
+
+        data[bugid] = {
+            "severity": bug["severity"],
+            "reasons": reasons,
+            "reasons_inline": utils.english_list(reasons),
+        }
+        self.extra_ni = data
+
+        return bug
+
+    def get_extra_for_needinfo_template(self):
+        return self.extra_ni
+
+    def columns(self):
+        return ["id", "summary", "severity", "reasons"]
+
+    def get_mail_to_auto_ni(self, bug):
+        for field in ["assigned_to", "triage_owner"]:
+            person = bug.get(field, "")
+            if person and not utils.is_no_assignee(person):
+                return {"mail": person, "nickname": bug[f"{field}_detail"]["nick"]}
+
+        return None
+
+    def get_bz_params(self, date):
+        fields = [
+            "triage_owner",
+            "assigned_to",
+            "severity",
+        ] + list(self.flags_map.keys())
+
+        target_tracking = ["blocking", "+"]
+
+        params = {
+            "include_fields": fields,
+            "resolution": "---",
+            "bug_severity": LOW_SEVERITY,
+            "j1": "OR",
+            "f1": "OP",
+            "f2": self.tracking_nightly,
+            "o2": "anyexact",
+            "v2": target_tracking,
+            "f3": self.tracking_beta,
+            "o3": "anyexact",
+            "v3": target_tracking,
+            "f4": self.tracking_release,
+            "o4": "anyexact",
+            "v4": target_tracking,
+            "f5": "CP",
+            "n6": 1,
+            "f6": "longdesc",
+            "o6": "casesubstring",
+            "v6": "could you consider increasing the severity of this tracked bug?",
+        }
+
+        return params
+
+
+if __name__ == "__main__":
+    SeverityTracked().run()

--- a/runauto_nag_daily.sh
+++ b/runauto_nag_daily.sh
@@ -162,6 +162,9 @@ python -m auto_nag.scripts.crash_signature_confirm --production
 # Confirm bugs with affected flags
 python -m auto_nag.scripts.affected_flag_confirm --production
 
+# Suggest increasing the severity for tracked bugs
+python -m auto_nag.scripts.severity_tracked --production
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m auto_nag.log --send

--- a/templates/severity_tracked.html
+++ b/templates/severity_tracked.html
@@ -1,0 +1,31 @@
+<p>The following {{ plural('bug has', data, pword='bugs have') }} a version tracking flag, however, {{ plural('its', data, pword='their') }} severity is low. {{ plural('Owner', data) }} got {{ plural('a needinfo request', data, pword='needinfo requests') }} to bump the severity:
+    <table {{ table_attrs }}>
+      <thead>
+        <tr>
+          <th>Bug</th><th>Summary</th><th>Severity</th><th>Tracking Flags</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for i, (bugid, summary, severity, reasons) in enumerate(data) -%}
+        <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+          <td>
+            <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+           </td>
+          <td>
+            {{ summary | e }}
+          </td>
+          <td>
+            {{ severity }}
+          </td>
+          <td>
+            <ul>
+              {% for reason in reasons -%}
+              <li>{{ reason }}</li>
+              {% endfor -%}
+            </ul>
+          </td>
+        </tr>
+        {% endfor -%}
+      </tbody>
+    </table>
+</p>

--- a/templates/severity_tracked_needinfo.txt
+++ b/templates/severity_tracked_needinfo.txt
@@ -1,0 +1,4 @@
+The severity field for this bug is set to {{ extra[bugid]["severity"] }}. However, the bug is marked as {{ extra[bugid]["reasons_inline"] }}.
+:{{ nickname }}, could you consider increasing the severity of this tracked bug?
+
+{{ documentation }}


### PR DESCRIPTION
Resolves #162 

## Autonag wiki page

**Low severity bugs with tracking status**

| **Purpose** | Suggest increasing the severity for bugs that are marked as blocking or are tracked for nightly, beta, or release. |
| ----------- | :---------------------------------------------------------- |
| **Action**  |  Needinfo the assignee or the triage owner if not assigned yet.                                     |
| **Code**    | severity_tracked.py                                         |


## Dry-run

```
2022-05-09 22:23:24,069 - INFO - Run tool severity_tracked.py
2022-05-09 22:23:32,267 - INFO - Tool severity_tracked.py has finished.
```

<details>
<summary>Click to expand the dry-run output!</summary>

<br>

<p>The following bugs have a version tracking flag, however, their severity is low. Owners got needinfo requests to bump the severity:
<table style="border:1px solid black;border-collapse:collapse;" border="1">
<thead>
<tr>
<th>Bug</th><th>Summary</th><th>Severity</th><th>Tracking Flags</th>
</tr>
</thead>
<tbody>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1767618">1767618</a>
</td>
<td>
[about:welcome] A blank area is displayed in the top right corner of the page when the browser is horizontally resized to 25%
</td>
<td>
S4
</td>
<td>
<ul>
<li>tracked for firefox102 (nightly)</li>
<li>tracked for firefox101 (beta)</li>
</ul>
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1767048">1767048</a>
</td>
<td>
Perma awsy/test_memory_usage.py TestMemoryUsage.test_open_tabs | AssertionError: heap-unclassified was negative: -161304 when Gecko 101 merges to Beta on 2022-05-02
</td>
<td>
S3
</td>
<td>
<ul>
<li>tracked for firefox101 (beta)</li>
</ul>
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1764602">1764602</a>
</td>
<td>
Swipe to navigate arrows flicker
</td>
<td>
S3
</td>
<td>
<ul>
<li>tracked for firefox101 (beta)</li>
</ul>
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1764290">1764290</a>
</td>
<td>
The pref for Firefox default PDF handler does not work as expected after Firefox update while it was manually set as default PDF handler before
</td>
<td>
S3
</td>
<td>
<ul>
<li>tracked for firefox100 (release)</li>
</ul>
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1761430">1761430</a>
</td>
<td>
Edit context menu items are incorrectly disabled/broken after searching with searchfox.org, or www.basschouten.com
</td>
<td>
S3
</td>
<td>
<ul>
<li>tracked for firefox101 (beta)</li>
</ul>
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1752655">1752655</a>
</td>
<td>
Slack issues on session restore: custom font not loaded, sidebar with thread conversation broken or: &#34;For some reason, Slack couldn&#8217;t load&#34;
</td>
<td>
S3
</td>
<td>
<ul>
<li>tracked for firefox100 (release)</li>
</ul>
</td>
</tr>
</tbody>
</table>
</p>
<p>Sincerely,<br>
Autonag bot
</p>
<p>
See the search query on <a href="https://mzl.la/3P9MVlG">Bugzilla</a>.
</p>

<p>
See the source / report issues on the <a href="https://github.com/mozilla/relman-auto-nag/">GitHub repo</a>
</p>


</details>