### PR TITLE
[topcrash_bad_severity] Needinfo to suggest increasing the severity

### DIFF
--- a/auto_nag/scripts/topcrash_bad_severity.py
+++ b/auto_nag/scripts/topcrash_bad_severity.py
@@ -2,18 +2,48 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from auto_nag import utils
 from auto_nag.bzcleaner import BzCleaner
 
 
 class TopcrashBadSeverity(BzCleaner):
+    def __init__(self):
+        super(TopcrashBadSeverity, self).__init__()
+        self.extra_ni = {}
+
     def description(self):
         return "Bugs with topcrash keyword but incorrect severity"
 
     def ignore_date(self):
         return True
 
+    def get_mail_to_auto_ni(self, bug):
+        for field in ["assigned_to", "triage_owner"]:
+            person = bug.get(field, "")
+            if not utils.is_no_assignee(person):
+                return {"mail": person, "nickname": bug[f"{field}_detail"]["nick"]}
+
+        return None
+
+    def handle_bug(self, bug, data):
+        bugid = str(bug["id"])
+        self.extra_ni[bugid] = {
+            "severity": bug["severity"],
+        }
+        return bug
+
+    def get_extra_for_needinfo_template(self):
+        return self.extra_ni
+
     def get_bz_params(self, date):
+        fields = [
+            "triage_owner",
+            "assigned_to",
+            "severity",
+        ]
+
         return {
+            "include_fields": fields,
             "resolution": ["---"],
             "bug_severity": [
                 "S3",
@@ -25,6 +55,10 @@ class TopcrashBadSeverity(BzCleaner):
             ],
             "keywords": "topcrash",
             "keywords_type": "allwords",
+            "n1": 1,
+            "f1": "longdesc",
+            "o1": "casesubstring",
+            "v1": "could you consider increasing the severity of this top-crash bug?",
         }
 
 

--- a/templates/topcrash_bad_severity_needinfo.txt
+++ b/templates/topcrash_bad_severity_needinfo.txt
@@ -1,0 +1,4 @@
+The severity field for this bug is set to {{ extra[bugid]["severity"] }}. However, the bug has the `topcrash` keyword.
+:{{ nickname }}, could you consider increasing the severity of this top-crash bug? If the crash isn't "top" anymore, could you drop the `topcrash` keyword?
+
+{{ documentation }}


### PR DESCRIPTION
Resolves #1407 

To be consistent with other tools, this tool will needinfo the assignee, if not assigned, it will needinfo the triage owner.

## Autonag wiki page

```diff
- Top crashers vs normal severity
+ Top crashers with low severity

- Purpose: Consistency and help getting traction on bugs.
+ Purpose: Consistency and help getting traction on topcrach bugs.
- Action: No action yet
+ Action: Needinfo the assignee or the triage owner if not assigned yet
Example: Bug 1471692
Code: topcrash_bad_severity.py
```