### PR TITLE
Make regression_set_status_flags look for bugs created in past 21 days instead of just 7 days

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -465,6 +465,7 @@
     "additional_receivers": ["jcristau@mozilla.com"]
   },
   "regression_set_status_flags": {
+    "days_lookup": 21,
     "additional_receivers": ["jcristau@mozilla.com"],
     "component_exception": ["Testing::geckodriver"]
   },

--- a/auto_nag/scripts/regression_set_status_flags.py
+++ b/auto_nag/scripts/regression_set_status_flags.py
@@ -23,7 +23,6 @@ class RegressionSetStatusFlags(BzCleaner):
         return "Set release status flags based on info from the regressing bug"
 
     def get_bz_params(self, date):
-        # XXX should perhaps look further back than one week, e.g. a month?
         start_date, _ = self.get_dates(date)
 
         # Find all bugs with regressed_by information which were open after start_date or


### PR DESCRIPTION
This way we don't risk missing anything during merge periods.

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
