### PR TITLE
Don't try to needinfo regression authors, if they are inactive

### DIFF
--- a/auto_nag/scripts/needinfo_regression_author.py
+++ b/auto_nag/scripts/needinfo_regression_author.py
@@ -8,6 +8,7 @@ from libmozdata.bugzilla import Bugzilla
 
 from auto_nag import logger, utils
 from auto_nag.bzcleaner import BzCleaner
+from auto_nag.user_activity import UserActivity
 
 
 class RegressionSetStatusFlags(BzCleaner):
@@ -121,6 +122,18 @@ class RegressionSetStatusFlags(BzCleaner):
                 for comment in bug["comments"]
             ):
                 del bugs[str(bug_id)]
+
+        # Exclude bugs where the regressor author is inactive.
+        # TODO: We can drop this when https://github.com/mozilla/relman-auto-nag/issues/1465 is implemented.
+        user_activity = UserActivity()
+        inactive_users = user_activity.check_users(
+            set(bug["regressor_author_email"] for bug in bugs.values())
+        )
+        bugs = {
+            bug["id"]: bug
+            for bug in bugs.values()
+            if bug["regressor_author_email"] not in inactive_users
+        }
 
         Bugzilla(
             bugids=self.get_list_bugs(bugs),

--- a/auto_nag/scripts/needinfo_regression_author.py
+++ b/auto_nag/scripts/needinfo_regression_author.py
@@ -130,8 +130,8 @@ class RegressionSetStatusFlags(BzCleaner):
             set(bug["regressor_author_email"] for bug in bugs.values())
         )
         bugs = {
-            bug["id"]: bug
-            for bug in bugs.values()
+            bug_id: bug
+            for bug_id, bug in bugs.items()
             if bug["regressor_author_email"] not in inactive_users
         }
 


### PR DESCRIPTION
Until #1465 is implemented as a generic solution, we should at least avoid needinfoing inactive
regression author (as it can be pretty common).

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
