### PR TITLE
Handle getting the management chain when the superior and the person are the same

### DIFF
--- a/auto_nag/people.py
+++ b/auto_nag/people.py
@@ -311,6 +311,11 @@ class People:
         """
         result = set()
 
+        assert person in self.people
+        assert superior in self.people
+        if person == superior:
+            return result
+
         manager = self.get_manager_mail(person)
         while manager != superior:
             result.add(manager)


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->


This should fix the following error:
```
2022-06-07 12:00:13,724 - ERROR - Tool to_triage
Traceback (most recent call last):
  File "/home/rm_bot/relman-auto-nag/auto_nag/bzcleaner.py", line 745, in run
    self.send_email(date=date)
  File "/home/rm_bot/relman-auto-nag/auto_nag/bzcleaner.py", line 698, in send_email
    self.send_mails(title, dryrun=self.dryrun)
  File "/home/rm_bot/relman-auto-nag/auto_nag/nag_me.py", line 167, in send_mails
    mails = self.prepare_mails()
  File "/home/rm_bot/relman-auto-nag/auto_nag/nag_me.py", line 225, in prepare_mails
    person, manager
  File "/home/rm_bot/relman-auto-nag/auto_nag/people.py", line 319, in get_management_chain_mails
    raise Exception(f"Cannot identify {superior} as a superior of {person}")
Exception: Cannot identify xxxx@xxx.com as a superior of xxxx@xxx.com
```






## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
