### PR TITLE
Fix `mypy`

### DIFF
--- a/auto_nag/scripts/fuzzing_bisection_without_regressed_by.py
+++ b/auto_nag/scripts/fuzzing_bisection_without_regressed_by.py
@@ -3,6 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import re
+from typing import Dict
 
 import requests
 from libmozdata.bugzilla import Bugzilla, BugzillaUser
@@ -48,8 +49,8 @@ class FuzzingBisectionWithoutRegressedBy(BzCleaner):
     def __init__(self) -> None:
         super().__init__()
         self.people = People.get_instance()
-        self.autofix_regressed_by = {}
-        self.bzmail_to_nickname = {}
+        self.autofix_regressed_by: Dict[str, str] = {}
+        self.bzmail_to_nickname: Dict[str, str] = {}
 
     def description(self):
         return "Bugs with a fuzzing bisection and without regressed_by"


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

This should fix the following [error in `mypy`](https://community-tc.services.mozilla.com/tasks/OZhC-o8mT7GPATruFq4BUA/runs/0/logs/public/logs/live.log):
```
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1
auto_nag/scripts/fuzzing_bisection_without_regressed_by.py:51: error:(B Need type annotation for (B"autofix_regressed_by"(B (hint: (B"autofix_regressed_by: Dict[<type>, <type>] = ..."(B)(B
auto_nag/scripts/fuzzing_bisection_without_regressed_by.py:52: error:(B Need type annotation for (B"bzmail_to_nickname"(B (hint: (B"bzmail_to_nickname: Dict[<type>, <type>] = ..."(B)(B
Found 2 errors in 1 file (checked 119 source files)(B
```






## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
