### PR TITLE
Add a tool to identify teams with no team managers defined in our mapping and team managers that are no longer there

### DIFF
--- a/auto_nag/scripts/vacant_team_manager.py
+++ b/auto_nag/scripts/vacant_team_manager.py
@@ -44,7 +44,7 @@ class TeamManagerVacant(BzCleaner, Nag):
         return self.template()
 
     def identify_vacant_teams(self) -> List[dict]:
-        # Filter out products and components that are not active
+        # We need team names for active components only.
         teams = {
             component["team_name"]
             for product in self.fetch_teams()

--- a/auto_nag/scripts/vacant_team_manager.py
+++ b/auto_nag/scripts/vacant_team_manager.py
@@ -3,7 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-from typing import List, Optional, Set
+from typing import List, Set
 
 from libmozdata.bugzilla import BugzillaProduct
 
@@ -85,9 +85,6 @@ class TeamManagerVacant(BzCleaner, Nag):
 
     def organize_nag(self, data: List[dict]) -> List[dict]:
         return data
-
-    def get_query_url_for_components(self, components: List[str]) -> Optional[str]:
-        return None
 
     def get_cc(self) -> Set[str]:
         return set()

--- a/auto_nag/scripts/vacant_team_manager.py
+++ b/auto_nag/scripts/vacant_team_manager.py
@@ -60,7 +60,7 @@ class TeamManagerVacant(BzCleaner, Nag):
         team_managers = TeamManagers()
         vacant_teams = []
         for team in teams:
-            manager = team_managers.get_team_manager(team, no_fallback=True)
+            manager = team_managers.get_team_manager(team, fallback=False)
 
             if manager is not None and manager["mozilla_email"] is not None:
                 continue

--- a/auto_nag/scripts/vacant_team_manager.py
+++ b/auto_nag/scripts/vacant_team_manager.py
@@ -3,16 +3,15 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-from typing import List, Set
+from typing import List
 
 from libmozdata.bugzilla import BugzillaProduct
 
 from auto_nag.bzcleaner import BzCleaner
-from auto_nag.nag_me import Nag
 from auto_nag.team_managers import TeamManagers
 
 
-class TeamManagerVacant(BzCleaner, Nag):
+class TeamManagerVacant(BzCleaner):
     def __init__(self) -> None:
         super(TeamManagerVacant, self).__init__()
         self.query_url = None
@@ -39,9 +38,6 @@ class TeamManagerVacant(BzCleaner, Nag):
         ).wait()
 
         return data
-
-    def nag_template(self) -> str:
-        return self.template()
 
     def identify_vacant_teams(self) -> List[dict]:
         # We need team names for active components only.
@@ -82,12 +78,6 @@ class TeamManagerVacant(BzCleaner, Nag):
 
     def get_email_data(self, date: str, bug_ids: List[int]) -> List[dict]:
         return self.identify_vacant_teams()
-
-    def organize_nag(self, data: List[dict]) -> List[dict]:
-        return data
-
-    def get_cc(self) -> Set[str]:
-        return set()
 
 
 if __name__ == "__main__":

--- a/auto_nag/scripts/vacant_team_manager.py
+++ b/auto_nag/scripts/vacant_team_manager.py
@@ -15,7 +15,6 @@ class TeamManagerVacant(BzCleaner):
     def __init__(self) -> None:
         super(TeamManagerVacant, self).__init__()
         self.query_url = None
-        self.inactive_weeks_number = self.get_config("inactive_weeks_number", 26)
 
     def description(self) -> str:
         return "Teams with managers that need to be assigned"

--- a/auto_nag/scripts/vacant_team_manager.py
+++ b/auto_nag/scripts/vacant_team_manager.py
@@ -1,0 +1,92 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+from typing import List, Optional, Set
+
+from libmozdata.bugzilla import BugzillaProduct
+
+from auto_nag.bzcleaner import BzCleaner
+from auto_nag.nag_me import Nag
+from auto_nag.team_managers import TeamManagers
+
+
+class TeamManagerVacant(BzCleaner, Nag):
+    def __init__(self) -> None:
+        super(TeamManagerVacant, self).__init__()
+        self.query_url = None
+        self.inactive_weeks_number = self.get_config("inactive_weeks_number", 26)
+
+    def description(self) -> str:
+        return "Teams with managers that need to be assigned"
+
+    def fetch_teams(self) -> List[dict]:
+        data = []
+        include_fields = [
+            "is_active",
+            "components.team_name",
+            "components.is_active",
+        ]
+
+        def product_handler(product: dict):
+            data.append(product)
+
+        BugzillaProduct(
+            product_names=self.get_products(),
+            include_fields=include_fields,
+            product_handler=product_handler,
+        ).wait()
+
+        return data
+
+    def nag_template(self) -> str:
+        return self.template()
+
+    def identify_vacant_teams(self) -> List[dict]:
+        # Filter out products and components that are not active
+        teams = set(
+            component["team_name"]
+            for product in self.fetch_teams()
+            if product["is_active"]
+            for component in product["components"]
+            if component["is_active"]
+        )
+        # Remove catch-all teams
+        teams -= set(("Mozilla", "Other"))
+        # Add "fallback" so we make sure the "fallback" is active.
+        teams.add("fallback")
+
+        team_managers = TeamManagers()
+        vacant_teams = []
+        for team in teams:
+            manager = team_managers.get_team_manager(team, no_fallback=True)
+
+            if manager is not None and manager["mozilla_email"] is not None:
+                continue
+
+            info = {
+                "manager": manager["name"] if manager is not None else "Nobody",
+                "team": team,
+                "status": "No longer in people" if manager is not None else "Undefined",
+            }
+
+            vacant_teams.append(info)
+
+        return vacant_teams
+
+    def get_email_data(self, date: str, bug_ids: List[int]) -> List[dict]:
+        return self.identify_vacant_teams()
+
+    def organize_nag(self, data: List[dict]) -> List[dict]:
+        return data
+
+    def get_query_url_for_components(self, components: List[str]) -> Optional[str]:
+        return None
+
+    def get_cc(self) -> Set[str]:
+        return set()
+
+
+if __name__ == "__main__":
+    TeamManagerVacant().run()

--- a/auto_nag/scripts/vacant_team_manager.py
+++ b/auto_nag/scripts/vacant_team_manager.py
@@ -65,8 +65,13 @@ class TeamManagerVacant(BzCleaner, Nag):
             if manager is not None and manager["mozilla_email"] is not None:
                 continue
 
+            if manager is not None:
+                name = manager["name"]
+            else:
+                name = "Nobody"
+
             info = {
-                "manager": manager["name"] if manager is not None else "Nobody",
+                "manager": name,
                 "team": team,
                 "status": "No longer in people" if manager is not None else "Undefined",
             }

--- a/auto_nag/scripts/vacant_team_manager.py
+++ b/auto_nag/scripts/vacant_team_manager.py
@@ -45,15 +45,15 @@ class TeamManagerVacant(BzCleaner, Nag):
 
     def identify_vacant_teams(self) -> List[dict]:
         # Filter out products and components that are not active
-        teams = set(
+        teams = {
             component["team_name"]
             for product in self.fetch_teams()
             if product["is_active"]
             for component in product["components"]
             if component["is_active"]
-        )
+        }
         # Remove catch-all teams
-        teams -= set(("Mozilla", "Other"))
+        teams -= {"Mozilla", "Other"}
         # Add "fallback" so we make sure the "fallback" is active.
         teams.add("fallback")
 

--- a/auto_nag/scripts/vacant_triage_owner.py
+++ b/auto_nag/scripts/vacant_triage_owner.py
@@ -103,9 +103,6 @@ class TriageOwnerVacant(BzCleaner, Nag):
     def organize_nag(self, data):
         return data
 
-    def get_query_url_for_components(self, components):
-        return None
-
     def get_cc(self):
         return set()
 

--- a/auto_nag/team_managers.py
+++ b/auto_nag/team_managers.py
@@ -27,10 +27,10 @@ class TeamManagers:
             }
 
     def get_team_manager(
-        self, team_name: str, no_fallback: bool = False
+        self, team_name: str, fallback: bool = True
     ) -> Optional[Dict[str, str]]:
         if team_name not in self.managers:
-            if not no_fallback:
+            if fallback:
                 return self.managers["fallback"]
             else:
                 return None

--- a/auto_nag/team_managers.py
+++ b/auto_nag/team_managers.py
@@ -3,6 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import json
+from typing import Dict, Optional
 
 from auto_nag.people import People
 
@@ -25,8 +26,13 @@ class TeamManagers:
                 for team, manager in json.load(file).items()
             }
 
-    def get_team_manager(self, team_name):
+    def get_team_manager(
+        self, team_name: str, no_fallback: bool = False
+    ) -> Optional[Dict[str, str]]:
         if team_name not in self.managers:
-            return self.managers["fallback"]
+            if not no_fallback:
+                return self.managers["fallback"]
+            else:
+                return None
 
         return self.managers[team_name]

--- a/runauto_nag_daily.sh
+++ b/runauto_nag_daily.sh
@@ -171,6 +171,9 @@ python -m auto_nag.scripts.severity_high_compat_priority --production
 # Suggest increasing the severity for tracked bugs
 python -m auto_nag.scripts.severity_tracked --production
 
+# Identify missing or inactive team managers
+python -m auto_nag.scripts.vacant_team_manager --production
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m auto_nag.log --send

--- a/templates/vacant_team_manager.html
+++ b/templates/vacant_team_manager.html
@@ -1,0 +1,24 @@
+<p>The following {{ plural('team is', data, pword='teams are') }} missing an active team manager:
+  <table {{ table_attrs }}>
+    <thead>
+      <tr>
+        <th>Team</th><th>Team Manager</th><th>Team Manager Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for i, row in enumerate(data) -%}
+      <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+        <td>
+          {{ row["team"] }}
+        </td>
+        <td>
+          {{ row["manager"] }}
+        </td>
+        <td>
+          {{ row["status"] }}
+        </td>
+      </tr>
+      {% endfor -%}
+    </tbody>
+  </table>
+</p>


### PR DESCRIPTION
Fixes #1347 and fixes #1387

## Checklist

- [x] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
