### PR TITLE
Prevent raising exceptions in extracting the management chain for some tools

### DIFF
--- a/auto_nag/escalation.py
+++ b/auto_nag/escalation.py
@@ -76,6 +76,18 @@ class Supervisor(object):
 
         return sup
 
+    def is_hierarchical_supervisor(self) -> bool:
+        """Identify if the supervisor is a superior in the management chain"""
+        return bool(
+            NPLUS_PAT.match(self.who)
+            or self.who
+            in (
+                "director",
+                "vp",
+                "self",
+            )
+        )
+
     def __str__(self):
         return self.who
 
@@ -124,6 +136,16 @@ class Escalation(object):
             "normal": Escalation._get_steps("normal", people, data),
             "default": Escalation._get_steps("default", people, data),
         }
+
+    def is_hierarchical_escalation_only(self) -> bool:
+        """Identify if all escalation steps are pointing to a superior in the
+        management chain.
+        """
+        return all(
+            step.supervisor.is_hierarchical_supervisor()
+            for steps in self.data.values()
+            for step in steps
+        )
 
     def get_supervisor(self, priority, days, person, **kwargs):
         steps = self.data[priority]

--- a/auto_nag/nag_me.py
+++ b/auto_nag/nag_me.py
@@ -198,6 +198,10 @@ class Nag(object):
         if not template:
             return []
 
+        # If we escalating only to hierarchical mangers, we should always have a
+        # management chain.
+        fail_on_missing_mgmt_chain = self.escalation.is_hierarchical_escalation_only()
+
         extra = self.get_extra_for_nag_template()
         env = Environment(loader=FileSystemLoader("templates"))
         template = env.get_template(template)
@@ -222,7 +226,7 @@ class Nag(object):
                     components |= self.triage_owners_components[person]
 
                 management_chain |= self.people.get_management_chain_mails(
-                    person, manager
+                    person, manager, fail_on_missing_mgmt_chain
                 )
 
             if components:

--- a/auto_nag/people.py
+++ b/auto_nag/people.py
@@ -302,11 +302,24 @@ class People:
                 return prev
         return mail
 
-    def get_management_chain_mails(self, person: str, superior: str) -> Set[str]:
+    def get_management_chain_mails(
+        self, person: str, superior: str, raise_on_missing: bool = True
+    ) -> Set[str]:
         """Get the mails of people in the management chain between a person and
         their superior.
 
-        Note: the person and the superior will not be returned in result.
+        Args:
+            person: the moz email of an employee.
+            superior: the moz email of one the employee's superiors.
+            raise_on_missing: If True, an exception will be raise when the
+                superior is not in the management hierarchy of the employee. If
+                False, an empty set will be returned instead of raising an
+                exception.
+
+        Returns:
+            A set of moz emails for people in the management chain between
+            `person` and `superior`. Emails for `person` and `superior` will not
+            be returned with the result.
         """
         result: Set[str] = set()
 
@@ -319,8 +332,14 @@ class People:
         while manager != superior:
             result.add(manager)
             manager = self.get_manager_mail(manager)
-            if not manager or manager in result:
+
+            if not manager:
+                if not raise_on_missing:
+                    return set()
                 raise Exception(f"Cannot identify {superior} as a superior of {person}")
+
+            if manager in result:
+                raise Exception("Circular management chain")
 
         return result
 


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Some tools are configured to escalate to people other than the managers. For such tools, when we escalate to a person who is not superior, we cannot extract the management chain. In this PR, we automatically detect such tools and avoid raising an exception.

## Tools that escalate for non-managers

https://github.com/mozilla/relman-auto-nag/blob/6ec5fb212491b584fdaa9f1242f4024531dee46f/auto_nag/scripts/configs/tools.json#L347

https://github.com/mozilla/relman-auto-nag/blob/6ec5fb212491b584fdaa9f1242f4024531dee46f/auto_nag/scripts/configs/tools.json#L415






## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [X] Type annotations added to new functions
- [X] Docs added to functions touched in main classes
- [X] Dry-run produced the expected results
