### PR TITLE
Change the thresholds for detecting inactive triage owners

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -189,7 +189,6 @@
     "must_run": ["Mon"]
   },
   "vacant_triage_owner": {
-    "inactive_weeks_number": 26,
     "must_run": ["Mon"]
   },
   "closed_dupeme": {

--- a/auto_nag/scripts/vacant_triage_owner.py
+++ b/auto_nag/scripts/vacant_triage_owner.py
@@ -12,10 +12,23 @@ from auto_nag.user_activity import UserActivity
 
 
 class TriageOwnerVacant(BzCleaner, Nag):
-    def __init__(self):
+    def __init__(
+        self,
+        activity_weeks_count: int = 8,
+        absent_weeks_count: int = 4,
+    ):
+        """Components with triage owner need to be assigned.
+
+        Args:
+            activity_weeks_count: the number of weeks of not doing any activity
+                on Bugzilla before considering a triage owner as inactive.
+            absent_weeks_count: number of weeks of not visiting Bugzilla before
+                considering a triage owner as inactive.
+        """
         super(TriageOwnerVacant, self).__init__()
         self.query_url = None
-        self.inactive_weeks_number = self.get_config("inactive_weeks_number", 26)
+        self.activity_weeks_count = activity_weeks_count
+        self.absent_weeks_count = absent_weeks_count
 
     def description(self):
         return "Components with triage owner need to be assigned"
@@ -67,7 +80,7 @@ class TriageOwnerVacant(BzCleaner, Nag):
             for component in product["components"]:
                 triage_owners.add(component["triage_owner"])
 
-        user_activity = UserActivity(self.inactive_weeks_number)
+        user_activity = UserActivity(self.activity_weeks_count, self.absent_weeks_count)
         inactive_users = user_activity.check_users(triage_owners)
 
         team_managers = TeamManagers()


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->






## Dry-run


<p>The following components are missing an active triage owner:
<table style="border:1px solid black;border-collapse:collapse;" border="1">
<thead>
<tr>
<th>Component</th><th>Team</th><th>Team Manager</th><th>Triage Owner</th><th>Triage Owner Status</th>
</tr>
</thead>
<tbody>
<tr bgcolor="#E0E0E0">
<td>
Core::MFBT
</td>
<td>
Low Level
</td>
<td>
Sylvestre Ledru
</td>
<td>
simon.giesecke@xxxx.xxx
</td>
<td>
Not seen on Bugzilla in last 4 weeks
</td>
</tr>
<tr >
<td>
Firefox::Extension Compatibility
</td>
<td>
Web Extensions
</td>
<td>
Thomas Elin
</td>
<td>
jorgev@xxxx.xxx
</td>
<td>
Not seen on Bugzilla in last 4 weeks
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Firefox::Headless
</td>
<td>
CI and Quality Tools
</td>
<td>
Marco Castelluccio
</td>
<td>
bdahl@xxxx.xxx
</td>
<td>
Account disabled
</td>
</tr>
<tr >
<td>
Firefox::Untriaged
</td>
<td>
Other
</td>
<td>
Thomas Elin
</td>
<td>

</td>
<td>
Not specified
</td>
</tr>
</tbody>
</table>
</p>



## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [X] Type annotations added to new functions
- [X] Docs added to functions touched in main classes
- [X] Dry-run produced the expected results
