### PR TITLE
[vacant_triage_owner] Show the number of untriaged bugs

### DIFF
--- a/auto_nag/scripts/vacant_triage_owner.py
+++ b/auto_nag/scripts/vacant_triage_owner.py
@@ -3,8 +3,11 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-from libmozdata.bugzilla import BugzillaProduct
+from typing import List
 
+from libmozdata.bugzilla import Bugzilla, BugzillaProduct
+
+from auto_nag import utils
 from auto_nag.bzcleaner import BzCleaner
 from auto_nag.nag_me import Nag
 from auto_nag.team_managers import TeamManagers
@@ -110,8 +113,44 @@ class TriageOwnerVacant(BzCleaner, Nag):
 
         return vacant_components
 
-    def get_email_data(self, date, bug_ids):
-        return self.identify_vacant_components()
+    def populate_num_untriaged_bugs(self, components: List[dict]) -> None:
+        """Add the number of untriaged bugs and the URL to its search query to
+        the provided components.
+
+        The method will mutate the provided dictionaries to add the results.
+        """
+
+        def handler(bug, data):
+            data["untriaged_bugs"] += 1
+
+        queries = [None] * len(components)
+        for i, component in enumerate(components):
+            params = {
+                "resolution": "---",
+                "severity": "--",
+                "product": component["product"],
+                "component": component["component"],
+            }
+            component["untriaged_bugs"] = 0
+            component["untriaged_bugs_url"] = utils.get_bz_search_url(params)
+            query = Bugzilla(
+                params,
+                bughandler=handler,
+                include_fields="-",
+                bugdata=component,
+            ).get_data()
+
+            queries[i] = query
+
+        # Since we query Bugzilla concurrently, we need to wait for the results
+        # form all queries.
+        for query in queries:
+            query.wait()
+
+    def get_email_data(self, date, bug_ids) -> List[dict]:
+        components = self.identify_vacant_components()
+        self.populate_num_untriaged_bugs(components)
+        return components
 
     def organize_nag(self, data):
         return data

--- a/auto_nag/scripts/vacant_triage_owner.py
+++ b/auto_nag/scripts/vacant_triage_owner.py
@@ -128,6 +128,7 @@ class TriageOwnerVacant(BzCleaner, Nag):
             params = {
                 "resolution": "---",
                 "severity": "--",
+                "bug_type": "defect",
                 "product": component["product"],
                 "component": component["component"],
             }

--- a/templates/vacant_triage_owner.html
+++ b/templates/vacant_triage_owner.html
@@ -2,7 +2,7 @@
   <table {{ table_attrs }}>
     <thead>
       <tr>
-        <th>Component</th><th>Team</th><th>Team Manager</th><th>Triage Owner</th><th>Triage Owner Status</th>
+        <th>Component</th><th>Team</th><th>Team Manager</th><th>Triage Owner</th><th>Triage Owner Status</th><th>Untriaged Bugs</th>
       </tr>
     </thead>
     <tbody>
@@ -22,6 +22,9 @@
         </td>
         <td>
           {{ row["status"] }}
+        </td>
+        <td>
+          <a href="{{ row["untriaged_bugs_url"] }}">{{ row["untriaged_bugs"] }}</a>
         </td>
       </tr>
       {% endfor -%}


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
Resolves #1489 



## Dry-run

<p>The following components are missing an active triage owner:
<table style="border:1px solid black;border-collapse:collapse;" border="1">
<thead>
<tr>
<th>Component</th><th>Team</th><th>Team Manager</th><th>Triage Owner</th><th>Triage Owner Status</th><th>Untriaged Bugs</th>
</tr>
</thead>
<tbody>
<tr bgcolor="#E0E0E0">
<td>
Core::MFBT
</td>
<td>
Low Level
</td>
<td>
Sylvestre Ledru
</td>
<td>
simon.giesecke@xxxx.xxx
</td>
<td>
Not seen on Bugzilla in last 4 weeks
</td>
<td>
<a href="https://bugzilla.mozilla.org/buglist.cgi?resolution=---&severity=--&bug_type=defect&product=Core&component=MFBT">13</a>
</td>
</tr>
<tr >
<td>
Firefox::Extension Compatibility
</td>
<td>
Web Extensions
</td>
<td>
Thomas Elin
</td>
<td>
jorgev@xxxx.xxx
</td>
<td>
Not seen on Bugzilla in last 4 weeks
</td>
<td>
<a href="https://bugzilla.mozilla.org/buglist.cgi?resolution=---&severity=--&bug_type=defect&product=Firefox&component=Extension+Compatibility">3</a>
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Firefox::Headless
</td>
<td>
CI and Quality Tools
</td>
<td>
Marco Castelluccio
</td>
<td>
bdahl@xxxx.xxx
</td>
<td>
Account disabled
</td>
<td>
<a href="https://bugzilla.mozilla.org/buglist.cgi?resolution=---&severity=--&bug_type=defect&product=Firefox&component=Headless">0</a>
</td>
</tr>
<tr >
<td>
Firefox::Untriaged
</td>
<td>
Other
</td>
<td>
Thomas Elin
</td>
<td>

</td>
<td>
Not specified
</td>
<td>
<a href="https://bugzilla.mozilla.org/buglist.cgi?resolution=---&severity=--&bug_type=defect&product=Firefox&component=Untriaged">22</a>
</td>
</tr>
</tbody>
</table>
</p>



## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [x] Type annotations added to new functions
- [x] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
