### PR TITLE
Remove white lines between PR description and checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,14 +2,6 @@
 Please describe why and what this Pull Request is doing
 -->
 
-
-
-
-
-
-
-
-
 ## Checklist
 
 <!---


### PR DESCRIPTION
They were initially added to leave space for the description, but we now have a placeholder so they don't seem necessary anymore

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
