### PR TITLE
Notify about tracked bugs with no assignee

### DIFF
--- a/auto_nag/scripts/tracked_unassigned.py
+++ b/auto_nag/scripts/tracked_unassigned.py
@@ -1,0 +1,139 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from libmozdata import utils as lmdutils
+from libmozdata.release_calendar import get_calendar
+
+from auto_nag import utils
+from auto_nag.bzcleaner import BzCleaner
+from auto_nag.team_managers import TeamManagers
+
+TARGET_CHANNELS = ["release", "beta", "nightly"]
+
+
+class TrackedUnassigned(BzCleaner):
+    def __init__(self):
+        super().__init__()
+        self.init_versions()
+        self.version_flags = []
+        self.team_managers = TeamManagers()
+
+        soft_freeze_date = get_calendar()[0]["soft freeze"]
+        today = lmdutils.get_date_ymd("today")
+        self.soft_freeze_days = (soft_freeze_date - today).days
+        self.extra_ni = {"soft_freeze_days": self.soft_freeze_days}
+
+    def description(self):
+        return "Tracked bugs with no assignee"
+
+    def get_extra_for_needinfo_template(self):
+        return self.extra_ni
+
+    def columns(self):
+        return ["id", "summary", "reasons", "is_regression"]
+
+    def handle_bug(self, bug, data):
+        bugid = str(bug["id"])
+
+        bug_trackings = [
+            flag
+            for flag in self.version_flags
+            if bug.get(flag["tracking_field"]) in ("blocking", "+")
+            and bug.get(flag["status_field"]) in ("affected", "---")
+        ]
+
+        reasons = [
+            "{tracking_type} firefox{version} ({channel})".format(
+                tracking_type=(
+                    "tracked for" if bug[flag["tracking_field"]] == "+" else "blocking"
+                ),
+                version=flag["version"],
+                channel=flag["channel"],
+            )
+            for flag in bug_trackings
+        ]
+
+        is_regression = "regression" in bug["keywords"]
+        show_soft_freeze_comment = self.soft_freeze_days <= 14 and is_regression
+
+        data[bugid] = {
+            "reasons": reasons,
+            "is_regression": is_regression,
+        }
+
+        self.extra_ni[bugid] = {
+            "reasons": utils.english_list(reasons),
+            "show_soft_freeze_comment": show_soft_freeze_comment,
+        }
+
+        return bug
+
+    def get_bz_params(self, date):
+        fields = [
+            "keywords",
+            "component.team_name",
+            "components.team_name",
+            "triage_owner",
+        ]
+
+        params = {
+            "include_fields": fields,
+            "resolution": "---",
+            "f1": "OP",
+            "j1": "OR",
+        }
+        for channel in TARGET_CHANNELS:
+            version = self.versions[channel]
+            tracking_field = utils.get_flag(version, "tracking", channel)
+            status_field = utils.get_flag(version, "status", channel)
+            fields.extend((tracking_field, status_field))
+
+            # We need this to explain the needinfo
+            self.version_flags.append(
+                {
+                    "version": version,
+                    "channel": channel,
+                    "tracking_field": tracking_field,
+                    "status_field": status_field,
+                }
+            )
+
+            n = int(utils.get_last_field_num(params))
+            params.update(
+                {
+                    f"f{n}": "OP",
+                    f"f{n+1}": tracking_field,
+                    f"o{n+1}": "anyexact",
+                    f"v{n+1}": ["+", "blocking"],
+                    f"f{n+2}": status_field,
+                    f"o{n+2}": "anyexact",
+                    f"v{n+2}": ["---", "affected"],
+                    f"f{n+3}": "CP",
+                }
+            )
+        n = int(utils.get_last_field_num(params))
+        params[f"f{n}"] = "CP"
+        utils.get_empty_assignees(params)
+
+        return params
+
+    def get_mail_to_auto_ni(self, bug):
+        manager = self.team_managers.get_component_manager(bug["component"], False)
+        if manager:
+            return {
+                "mail": manager["bz_email"],
+                "nickname": manager["nick"],
+            }
+
+        if not bug["triage_owner"]:
+            return None
+
+        return {
+            "mail": bug["triage_owner"],
+            "nickname": bug["triage_owner_detail"]["nick"],
+        }
+
+
+if __name__ == "__main__":
+    TrackedUnassigned().run()

--- a/templates/tracked_unassigned.html
+++ b/templates/tracked_unassigned.html
@@ -1,0 +1,28 @@
+<p>The following {{ plural('bug has', data, pword='bugs have') }} a version tracking flag, however, {{ plural('it is', data, pword='they are') }} not assigned (when the bug is red, then it is a regression):
+    <table {{ table_attrs }}>
+      <thead>
+        <tr>
+          <th>Bug</th><th>Summary</th><th>Tracking Flags</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for i, (bugid, summary, reasons, is_regression) in enumerate(data) -%}
+        <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+          <td {% if is_regression %}bgcolor="#FFB8B8"{% endif %}>
+            <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+           </td>
+          <td>
+            {{ summary | e }}
+          </td>
+          <td>
+            <ul>
+              {% for reason in reasons -%}
+              <li>{{ reason }}</li>
+              {% endfor -%}
+            </ul>
+          </td>
+        </tr>
+        {% endfor -%}
+      </tbody>
+    </table>
+</p>

--- a/templates/tracked_unassigned_needinfo.txt
+++ b/templates/tracked_unassigned_needinfo.txt
@@ -1,0 +1,9 @@
+The bug is marked as {{ extra[bugid]["reasons"] }}.{% if extra[bugid]["show_soft_freeze_comment"] %} We have limited time to fix this, the soft freeze is in {{ extra["soft_freeze_days"] }} days.{% endif %} However, the bug still isn't assigned.
+
+{% if extra[bugid]["show_soft_freeze_comment"] -%}
+:{{ nickname }}, should we ship with this regression or backout the regressor? Please coordinate with the release managers.
+{% else %}
+:{{ nickname }}, could you please find an assignee for this tracked bug? If you disagree with the decision, please talk with the release managers.
+{% endif %}
+
+{{ documentation }}


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Resolves #265 and resolves #1469


## Autonag wiki page
```wiki
{{AutonagRule
  | Rule name = Tracked bugs with no assignee
  | Purpose   = Notify about tracked bugs with no assignee
  | Action    = Needinfo the team manager and fallback on the triage owner if we have no team manager defined in our config
  | Source    = tracked_unassigned.py 
}}
```

## Dry-run

```
2022-06-16 19:18:20,662 - INFO - The bugs: 1769811
2022-06-16 19:18:21,505 - INFO - Tool tracked_unassigned.py has finished.
```

<details>
<summary>Click to expand the dry-run output!</summary><br>

<p>The following bugs have a version tracking flag, however, they are not assigned (when the bug is red, then it is a regression):
<table style="border:1px solid black;border-collapse:collapse;" border="1">
<thead>
<tr>
<th>Bug</th><th>Summary</th><th>Tracking Flags</th>
</tr>
</thead>
<tbody>
<tr bgcolor="#E0E0E0">
<td >
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1774155">1774155</a>
</td>
<td>
Windows 32-bit Crash in [@ OOM | large | NS_ABORT_OOM | mozilla::dom::DeprecationWarning]
</td>
<td>
<ul>
<li>tracked for firefox102 (beta)</li>
</ul>
</td>
</tr>
<tr >
<td bgcolor="#FFB8B8">
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1773907">1773907</a>
</td>
<td>
installer download on java.com lacks file extension .exe
</td>
<td>
<ul>
<li>tracked for firefox102 (beta)</li>
</ul>
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td >
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1772839">1772839</a>
</td>
<td>
Crash in [@ gfxPlatform::FallbackFromAcceleration]
</td>
<td>
<ul>
<li>tracked for firefox102 (beta)</li>
<li>tracked for firefox103 (nightly)</li>
</ul>
</td>
</tr>
<tr >
<td >
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1772739">1772739</a>
</td>
<td>
Clicking a link after using back button navigates to an incorrect page
</td>
<td>
<ul>
<li>tracked for firefox102 (beta)</li>
<li>tracked for firefox103 (nightly)</li>
</ul>
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td bgcolor="#FFB8B8">
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1772225">1772225</a>
</td>
<td>
PDF from Google Docs prints out with little artifacts (rasterized text?)
</td>
<td>
<ul>
<li>tracked for firefox102 (beta)</li>
</ul>
</td>
</tr>
<tr >
<td bgcolor="#FFB8B8">
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1769811">1769811</a>
</td>
<td>
Broken Chinese/Japanese fonts with win32k Lockdown enabled
</td>
<td>
<ul>
<li>tracked for firefox102 (beta)</li>
</ul>
</td>
</tr>
</tbody>
</table>
</p>

</details>



### Needinfo example

The bug is marked as tracked for firefox102 (beta) and tracked for firefox103 (nightly). However, the bug still isn't assigned.


:denschub, could you please find an assignee for this tracked bug? If you disagree with the decision, please talk with the release managers.


For more information, please visit [auto_nag documentation](https://wiki.mozilla.org/Release_Management/autonag#tracked_unassigned.py).




## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [x] Type annotations added to new functions
- [x] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
