### PR TITLE
Avoid warning when backport patches are attached to closed bugs

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -74,7 +74,6 @@
     "must_run": ["Mon"]
   },
   "patch_closed_bug": {
-    "days_count": 2,
     "additional_receivers": "rm"
   },
   "has_str_no_hasstr": {

--- a/auto_nag/scripts/patch_closed_bug.py
+++ b/auto_nag/scripts/patch_closed_bug.py
@@ -18,11 +18,11 @@ class PatchClosedBug(BzCleaner):
         """Constructor
 
         Args:
-            days_count: represents the maximum number of days from the
-                submission date for an attachment to be considered.
-            wait_time: number of hours to wait after the attachment submission
-                before considering it. This time gap allow people to set missed
-                uplift flags, i.e., `approval-mozilla-*`.
+            days_count: the maximum number of days from the submission date for
+                an attachment to be considered.
+            wait_time: the number of hours to wait after the attachment
+                submission before considering it. This time gap allows people to
+                set missed uplift flags, i.e., `approval-mozilla-*`.
         """
         super(PatchClosedBug, self).__init__()
 

--- a/runauto_nag_daily.sh
+++ b/runauto_nag_daily.sh
@@ -157,7 +157,7 @@ python -m auto_nag.scripts.inactive_ni_pending --production
 python -m auto_nag.scripts.crash_signature_confirm --production
 
 # Bugs with patches after being closed
-# python -m auto_nag.scripts.patch_closed_bug --production
+python -m auto_nag.scripts.patch_closed_bug --production
 
 # Confirm bugs with affected flags
 python -m auto_nag.scripts.affected_flag_confirm --production


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Fixes #1409 


## Dry-run

<p>The following bug received a patch after being closed:
<table style="border:1px solid black;border-collapse:collapse;" border="1">
<thead>
<tr>
<th>Bug</th><th>Summary</th><th>Resolution</th><th>Last patch</th>
</tr>
</thead>
<tbody>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1775480">1775480</a>
</td>
<td>
Add more crash annotations for bug 1772839
</td>
<td>
4 days
</td>
<td>
4 days after resolution
</td>
</tr>
</tbody>
</table>
  </p>


## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [x] Type annotations added to new functions
- [x] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
