### PR TITLE
Add "to be announced" item in the pull request checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,3 +11,4 @@ The following should be done (and marked as completed) when applicable. Please d
 - [ ] Type annotations added to new functions
 - [ ] Docs added to functions touched in main classes
 - [ ] Dry-run produced the expected results
+- [ ] The `TBA` tag added if this is worth announcing


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

This is based on the discussion with @marco-c on Matrix. 

If the PR is worth announcing, we will add the `TBA` tag (To Be Announced) tag. Once we announce the change (i.e., sent to dev-platform/firefox-dev mailing lists and add to EE newsletter), we must replace `TBA` with `announced`.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
