### PR TITLE
Corrected round-robin config for component renames made by 1774288

### DIFF
--- a/auto_nag/scripts/configs/gfx_round_robin.json
+++ b/auto_nag/scripts/configs/gfx_round_robin.json
@@ -1,15 +1,14 @@
 {
   "fallback": "Jessie Bonisteel",
   "components": {
-    "Graphics::Canvas2D": "default",
-    "Graphics::CanvasWebGL": "default",
-    "Graphics::Color:Management": "default",
-    "Graphics": "default",
-    "Graphics::Layers": "default",
-    "Graphics::Text": "default",
-    "Graphics::WebRender": "default",
-    "Graphics::Image:Blocking": "default",
-    "Graphics::ImageLib": "default"
+    "Core::Graphics": "default",
+    "Core::Graphics: Canvas2D": "default",
+    "Core::Graphics: CanvasWebGL": "default",
+    "Core::Graphics: Color Management": "default",
+    "Core::Graphics: Image Blocking": "default",
+    "Core::Graphics: ImageLib": "default",
+    "Core::Graphics: Text": "default",
+    "Core::Graphics: WebRender": "default"
   },
   "default": {
     "calendar": "private://Gfx"

--- a/auto_nag/scripts/configs/gfx_round_robin.json
+++ b/auto_nag/scripts/configs/gfx_round_robin.json
@@ -1,15 +1,15 @@
 {
   "fallback": "Jessie Bonisteel",
   "components": {
-    "Canvas::2D": "default",
-    "Canvas::WebGL": "default",
-    "GFX::Color:Management": "default",
+    "Graphics::Canvas2D": "default",
+    "Graphics::CanvasWebGL": "default",
+    "Graphics::Color:Management": "default",
     "Graphics": "default",
     "Graphics::Layers": "default",
     "Graphics::Text": "default",
     "Graphics::WebRender": "default",
-    "Image:Blocking": "default",
-    "ImageLib": "default"
+    "Graphics::Image:Blocking": "default",
+    "Graphics::ImageLib": "default"
   },
   "default": {
     "calendar": "private://Gfx"


### PR DESCRIPTION
<!---
The changes made by [1774288](https://bugzilla.mozilla.org/show_bug.cgi?id=1774288) have broken the auto-nag system for certain Platform Graphics components.  This change updates the round-robin config with the new component names.

Note: I don't know how to dry-run this tool, so I have not tested this change.
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
