### PR TITLE
Detect review requests on inactive reviewers

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party = Levenshtein,alembic,dateutil,filelock,humanize,icalendar,icalevents,jinja2,libmozdata,numpy,pytz,requests,sqlalchemy,whatthepatch
+known_third_party = Levenshtein,alembic,dateutil,filelock,humanize,icalendar,icalevents,jinja2,libmozdata,numpy,pytz,requests,sqlalchemy,tenacity,whatthepatch
 line_length = 88
 multi_line_output=3
 include_trailing_comma=True

--- a/auto_nag/bzcleaner.py
+++ b/auto_nag/bzcleaner.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, Template
 from libmozdata import utils as lmdutils
 from libmozdata.bugzilla import Bugzilla
 
@@ -66,7 +66,7 @@ class BzCleaner(object):
         """Get the tool path"""
         return self.__tool_path__
 
-    def needinfo_template(self):
+    def needinfo_template_name(self):
         """Get the txt template filename"""
         return self.name() + "_needinfo.txt"
 
@@ -491,10 +491,7 @@ class BzCleaner(object):
         if not self.auto_needinfo:
             return {}
 
-        template_name = self.needinfo_template()
-        assert bool(template_name)
-        env = Environment(loader=FileSystemLoader("templates"))
-        template = env.get_template(template_name)
+        template = self.get_needinfo_template()
         res = {}
 
         doc = self.get_documentation()
@@ -534,6 +531,16 @@ class BzCleaner(object):
                         res[bugid]["comment"]["body"] = comment
 
         return res
+
+    def get_needinfo_template(self) -> Template:
+        """Get a template to render needinfo comment body"""
+
+        template_name = self.needinfo_template_name()
+        assert bool(template_name)
+        env = Environment(loader=FileSystemLoader("templates"))
+        template = env.get_template(template_name)
+
+        return template
 
     def has_individual_autofix(self, changes):
         # check if we have a dictionary with bug numbers as keys

--- a/auto_nag/scripts/inactive_reviewer.py
+++ b/auto_nag/scripts/inactive_reviewer.py
@@ -135,7 +135,7 @@ class InactiveReviewer(BzCleaner):
         result: Dict[int, dict] = {}
         for revision in revisions:
             # It is not useful to notify an inactive author about an inactive
-            # reviewer, thus we should exclude reversions with inactive authors.
+            # reviewer, thus we should exclude revisions with inactive authors.
             author_info = users[revision["author_phid"]]
             if author_info["status"] != UserStatus.ACTIVE:
                 continue

--- a/auto_nag/scripts/inactive_reviewer.py
+++ b/auto_nag/scripts/inactive_reviewer.py
@@ -194,7 +194,7 @@ class InactiveReviewer(BzCleaner):
     @staticmethod
     def _get_reviewer_status_note(reviewer: dict) -> str:
         if reviewer["is_resigned"]:
-            return "Resigned"
+            return "Resigned from review"
 
         status = reviewer["info"]["status"]
         if status == UserStatus.UNAVAILABLE:

--- a/auto_nag/scripts/inactive_reviewer.py
+++ b/auto_nag/scripts/inactive_reviewer.py
@@ -158,7 +158,7 @@ class InactiveReviewer(BzCleaner):
                 reviewer["info"] = reviewer_info
                 inactive_reviewers.append(reviewer)
 
-            if len(inactive_reviewers) == len(reviewers) or any(
+            if len(inactive_reviewers) == len(revision["reviewers"]) or any(
                 reviewer["is_blocking"] and not reviewer["is_accepted"]
                 for reviewer in inactive_reviewers
             ):

--- a/auto_nag/scripts/inactive_reviewer.py
+++ b/auto_nag/scripts/inactive_reviewer.py
@@ -1,0 +1,215 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import re
+from typing import Dict, List
+
+from libmozdata.connection import Connection
+from libmozdata.phabricator import PhabricatorAPI
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+from auto_nag import utils
+from auto_nag.bzcleaner import BzCleaner
+from auto_nag.user_activity import PHAB_CHUNK_SIZE, UserActivity, UserStatus
+
+PHAB_FILE_NAME_PAT = re.compile(r"phabricator-D([0-9]+)-url\.txt")
+
+
+class InactiveReviewer(BzCleaner):
+    """Bugs with patches that are waiting for review from inactive reviewers"""
+
+    def __init__(self):
+        super(InactiveReviewer, self).__init__()
+        self.phab = PhabricatorAPI(utils.get_login_info()["phab_api_key"])
+        self.user_activity = UserActivity(include_fields=["nick"], phab=self.phab)
+        self.ni_template = self.get_needinfo_template()
+
+    def description(self):
+        return "Bugs with inactive patch reviewers"
+
+    def columns(self):
+        return ["id", "summary", "revisions"]
+
+    def get_bugs(self, date="today", bug_ids=[], chunk_size=None):
+        bugs = super().get_bugs(date, bug_ids, chunk_size)
+
+        rev_ids = {rev_id for bug in bugs.values() for rev_id in bug["rev_ids"]}
+        revisions = self._get_revisions_with_inactive_reviewers(list(rev_ids))
+
+        for bugid, bug in list(bugs.items()):
+            inactive_revs = [
+                revisions[rev_id] for rev_id in bug["rev_ids"] if rev_id in revisions
+            ]
+            if inactive_revs:
+                bug["revisions"] = inactive_revs
+                self._add_needinfo(bugid, inactive_revs)
+            else:
+                del bugs[bugid]
+
+        # Resolving https://github.com/mozilla/relman-auto-nag/issues/1300 should clean this
+        # including improve the wording in the template (i.e., "See the search query on Bugzilla").
+        self.query_url = utils.get_bz_search_url({"bug_id": ",".join(bugs.keys())})
+
+        return bugs
+
+    def _add_needinfo(self, bugid: str, inactive_revs: list) -> None:
+        ni_mails = {rev["author"]["name"] for rev in inactive_revs}
+        nicknames = utils.english_list(
+            sorted({rev["author"]["nick"] for rev in inactive_revs})
+        )
+        comment = self.ni_template.render(
+            revisions=inactive_revs,
+            nicknames=nicknames,
+            plural=utils.plural,
+            documentation=self.get_documentation(),
+        )
+
+        self.autofix_changes[bugid] = {
+            "comment": {"body": comment},
+            "flags": [
+                {
+                    "name": "needinfo",
+                    "requestee": ni_mail,
+                    "status": "?",
+                    "new": "true",
+                }
+                for ni_mail in ni_mails
+            ],
+        }
+
+    def _get_revisions_with_inactive_reviewers(self, rev_ids: list) -> Dict[int, dict]:
+        revisions: List[dict] = []
+        for _rev_ids in Connection.chunks(rev_ids, PHAB_CHUNK_SIZE):
+            for revision in self._fetch_revisions(_rev_ids):
+                if (
+                    len(revision["attachments"]["reviewers"]["reviewers"]) == 0
+                    or revision["fields"]["status"]["value"] != "needs-review"
+                    or revision["fields"]["isDraft"]
+                ):
+                    continue
+
+                reviewers = [
+                    {
+                        "phid": reviewer["reviewerPHID"],
+                        "is_group": reviewer["reviewerPHID"].startswith("PHID-PROJ"),
+                        "is_blocking": reviewer["isBlocking"],
+                        "is_accepted": reviewer["status"] == "accepted",
+                    }
+                    for reviewer in revision["attachments"]["reviewers"]["reviewers"]
+                ]
+
+                # Group reviewers will be consider always active; so if there is
+                # no other reviewers blocking, we don't need to check further.
+                if any(
+                    reviewer["is_group"] or reviewer["is_accepted"]
+                    for reviewer in reviewers
+                ) and not any(
+                    not reviewer["is_accepted"]
+                    for reviewer in reviewers
+                    if reviewer["is_blocking"]
+                ):
+                    continue
+
+                revisions.append(
+                    {
+                        "rev_id": revision["id"],
+                        "title": revision["fields"]["title"],
+                        "author_phid": revision["fields"]["authorPHID"],
+                        "reviewers": reviewers,
+                    }
+                )
+
+        user_phids = set()
+        for revision in revisions:
+            user_phids.add(revision["author_phid"])
+            for reviewer in revision["reviewers"]:
+                user_phids.add(reviewer["phid"])
+
+        users = self.user_activity.get_phab_users_with_status(
+            list(user_phids), keep_active=True
+        )
+
+        result: Dict[int, dict] = {}
+        for revision in revisions:
+            # It is not useful to notify an inactive author about an inactive
+            # reviewer, thus we should exclude reversions with inactive authors.
+            author_info = users[revision["author_phid"]]
+            if author_info["status"] != UserStatus.ACTIVE:
+                continue
+
+            revision["author"] = author_info
+
+            inactive_reviewers = []
+            for reviewer in revision["reviewers"]:
+                if reviewer["is_group"]:
+                    continue
+
+                reviewer_info = users[reviewer["phid"]]
+                if reviewer_info["status"] == UserStatus.ACTIVE:
+                    continue
+
+                reviewer["info"] = reviewer_info
+                inactive_reviewers.append(reviewer)
+
+            if len(inactive_reviewers) == len(reviewers) or any(
+                reviewer["is_blocking"] and not reviewer["is_accepted"]
+                for reviewer in inactive_reviewers
+            ):
+                revision["reviewers"] = [
+                    reviewer["info"] for reviewer in inactive_reviewers
+                ]
+                result[revision["rev_id"]] = revision
+
+        return result
+
+    @retry(
+        wait=wait_exponential(min=4),
+        stop=stop_after_attempt(5),
+    )
+    def _fetch_revisions(self, ids: list):
+        return self.phab.request(
+            "differential.revision.search",
+            constraints={"ids": ids},
+            attachments={"reviewers": True},
+        )["data"]
+
+    def handle_bug(self, bug, data):
+        rev_ids = [
+            int(PHAB_FILE_NAME_PAT.findall(attachment["file_name"])[0])
+            for attachment in bug["attachments"]
+            if attachment["content_type"] == "text/x-phabricator-request"
+            and not attachment["is_obsolete"]
+        ]
+
+        if not rev_ids:
+            return
+
+        # It will be nicer to show a sorted list of patches
+        rev_ids.sort()
+
+        bugid = str(bug["id"])
+        data[bugid] = {
+            "rev_ids": rev_ids,
+        }
+        return bug
+
+    def get_bz_params(self, date):
+        fields = [
+            "attachments.file_name",
+            "attachments.content_type",
+            "attachments.is_obsolete",
+        ]
+        params = {
+            "include_fields": fields,
+            "resolution": "---",
+            "f1": "attachments.mimetype",
+            "o1": "equals",
+            "v1": "text/x-phabricator-request",
+        }
+
+        return params
+
+
+if __name__ == "__main__":
+    InactiveReviewer().run()

--- a/auto_nag/scripts/inactive_reviewer.py
+++ b/auto_nag/scripts/inactive_reviewer.py
@@ -97,6 +97,7 @@ class InactiveReviewer(BzCleaner):
                         "is_group": reviewer["reviewerPHID"].startswith("PHID-PROJ"),
                         "is_blocking": reviewer["isBlocking"],
                         "is_accepted": reviewer["status"] == "accepted",
+                        "is_resigned": reviewer["status"] == "resigned",
                     }
                     for reviewer in revision["attachments"]["reviewers"]["reviewers"]
                 ]
@@ -148,7 +149,10 @@ class InactiveReviewer(BzCleaner):
                     continue
 
                 reviewer_info = users[reviewer["phid"]]
-                if reviewer_info["status"] == UserStatus.ACTIVE:
+                if (
+                    not reviewer["is_resigned"]
+                    and reviewer_info["status"] == UserStatus.ACTIVE
+                ):
                     continue
 
                 reviewer["info"] = reviewer_info

--- a/auto_nag/user_activity.py
+++ b/auto_nag/user_activity.py
@@ -15,7 +15,7 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 from auto_nag import utils
 from auto_nag.people import People
 
-# The chunk size her should not be more than 100; which is the maximum number of
+# The chunk size here should not be more than 100; which is the maximum number of
 # items that Phabricator could return in one response.
 PHAB_CHUNK_SIZE = 100
 

--- a/auto_nag/user_activity.py
+++ b/auto_nag/user_activity.py
@@ -214,6 +214,9 @@ class UserActivity:
                     continue
 
                 user["phab_username"] = phab_user["fields"]["username"]
+                user["unavailable_until"] = phab_user["attachments"]["availability"][
+                    "until"
+                ]
 
         return users
 

--- a/auto_nag/user_activity.py
+++ b/auto_nag/user_activity.py
@@ -156,6 +156,9 @@ class UserActivity:
         return users
 
     def _get_status_from_phab_user(self, user: dict) -> UserStatus:
+        if "disabled" in user["fields"]["roles"]:
+            return UserStatus.DISABLED
+
         availability = user["attachments"]["availability"]
         if availability["value"] != "available":
             # We do not need to consider the user inactive they will be

--- a/auto_nag/user_activity.py
+++ b/auto_nag/user_activity.py
@@ -2,10 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from datetime import timedelta
 from enum import Enum, auto
 
 from libmozdata import utils as lmdutils
 from libmozdata.bugzilla import BugzillaUser
+from libmozdata.connection import Connection
+from libmozdata.phabricator import PhabricatorAPI
+from tenacity import retry, stop_after_attempt, wait_exponential
 
 from auto_nag import utils
 from auto_nag.people import People
@@ -14,11 +18,18 @@ DEFAULT_ACTIVITY_WEEKS = 26
 DEFAULT_ABSENT_WEEKS = 26
 
 
+# The chunk size her should not be more than 100; which is the maximum number of
+# items that Phabricator could return in one response.
+PHAB_CHUNK_SIZE = 100
+
+
 class UserStatus(Enum):
+    ACTIVE = auto()
     UNDEFINED = auto()
     DISABLED = auto()
     INACTIVE = auto()
     ABSENT = auto()
+    UNAVAILABLE = auto()
 
 
 class UserActivity:
@@ -27,16 +38,27 @@ class UserActivity:
         activity_weeks_count=DEFAULT_ACTIVITY_WEEKS,
         absent_weeks_count=DEFAULT_ABSENT_WEEKS,
         include_fields=[],
+        unavailable_max_days: int = 7,
     ) -> None:
         self.activity_weeks_count = activity_weeks_count
         self.absent_weeks_count = absent_weeks_count
         self.include_fields = include_fields
         self.people = People.get_instance()
+        self.phab = None
+        self.availability_limit = (
+            lmdutils.get_date_ymd("today") + timedelta(unavailable_max_days)
+        ).timestamp()
 
         self.activity_limit = lmdutils.get_date("today", self.activity_weeks_count * 7)
         self.seen_limit = lmdutils.get_date("today", self.absent_weeks_count * 7)
 
-    def check_users(self, user_emails):
+    def _get_phab(self):
+        if not self.phab:
+            self.phab = PhabricatorAPI(utils.get_login_info()["phab_api_key"])
+
+        return self.phab
+
+    def check_users(self, user_emails) -> dict:
         # Employees will always be considered active
         user_emails = self.get_not_employees(user_emails)
 
@@ -52,7 +74,9 @@ class UserActivity:
             user_email for user_email in user_emails if user_email not in user_statuses
         ]
 
-        return self.get_bz_status(user_emails, user_statuses)
+        user_statuses.update(self.get_bz_users_with_status(user_emails))
+
+        return user_statuses
 
     def get_not_employees(self, user_emails):
         return [
@@ -61,7 +85,9 @@ class UserActivity:
             if not self.people.is_mozilla(user_email)
         ]
 
-    def get_bz_status(self, user_emails, user_statuses={}):
+    def get_bz_users_with_status(
+        self, user_names: list, keep_active: bool = False
+    ) -> dict:
         def handler(user, data):
             if not user["can_login"]:
                 user["status"] = UserStatus.DISABLED
@@ -75,14 +101,17 @@ class UserActivity:
                 or user["last_activity_time"] < self.activity_limit
             ):
                 user["status"] = UserStatus.INACTIVE
+            elif keep_active:
+                user["status"] = UserStatus.ACTIVE
             else:
                 return
 
             data[user["name"]] = user
 
+        users: dict = {}
         BugzillaUser(
-            user_data=user_statuses,
-            user_names=user_emails,
+            user_data=users,
+            user_names=user_names,
             user_handler=handler,
             include_fields=[
                 "name",
@@ -93,7 +122,48 @@ class UserActivity:
             + self.include_fields,
         ).wait()
 
-        return user_statuses
+        return users
+
+    def get_phab_users_with_status(self, user_phids: list, keep_active: bool = False):
+        bzid_to_phid = {
+            int(user["id"]): user["phid"]
+            for _user_phids in Connection.chunks(user_phids, PHAB_CHUNK_SIZE)
+            for user in self._fetch_bz_user_ids(user_phids=_user_phids)
+        }
+        if not bzid_to_phid:
+            return {}
+
+        if "id" not in self.include_fields:
+            self.include_fields.append("id")
+
+        user_bz_ids = list(bzid_to_phid.keys())
+        users = self.get_bz_users_with_status(user_bz_ids, keep_active=True)
+        users = {bzid_to_phid[user["id"]]: user for user in users.values()}
+
+        # To cover cases where a person is temporary off (e.g., long PTO), we
+        # will rely on the calendar from phab.
+        user_phids = [
+            phid for phid, user in users.items() if user["status"] == UserStatus.ACTIVE
+        ]
+
+        for _user_phids in Connection.chunks(user_phids, PHAB_CHUNK_SIZE):
+            for phab_user in self._fetch_phab_users(_user_phids):
+                availability = phab_user["attachments"]["availability"]
+                if availability["value"] != "available" and (
+                    not availability["until"]
+                    or availability["until"] > self.availability_limit
+                ):
+                    status = UserStatus.UNAVAILABLE
+                elif keep_active:
+                    status = UserStatus.ACTIVE
+                else:
+                    del users[phab_user["phid"]]
+                    continue
+
+                user = users[phab_user["phid"]]
+                user["status"] = status
+
+        return users
 
     def get_string_status(self, status: UserStatus):
         if status == UserStatus.UNDEFINED:
@@ -106,3 +176,23 @@ class UserActivity:
             return f"Not seen on Bugzilla in last {self.absent_weeks_count} weeks"
         else:
             return status.name
+
+    @retry(
+        wait=wait_exponential(min=4),
+        stop=stop_after_attempt(5),
+    )
+    def _fetch_phab_users(self, phids: list):
+        if len(phids) == 0:
+            return []
+
+        return self._get_phab().search_users(
+            constraints={"phids": phids},
+            attachments={"availability": True},
+        )
+
+    @retry(
+        wait=wait_exponential(min=4),
+        stop=stop_after_attempt(5),
+    )
+    def _fetch_bz_user_ids(self, *args, **kwargs):
+        return self._get_phab().load_bz_account(*args, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,5 @@ python-Levenshtein>=0.12.0
 pytz>=2018.9
 requests>=2.20.0
 sqlalchemy==1.3.24
+tenacity==8.0.1
 whatthepatch>=0.0.5

--- a/templates/inactive_reviewer.html
+++ b/templates/inactive_reviewer.html
@@ -1,0 +1,28 @@
+<p>The following {{ plural('bug has', data, pword='bugs have') }} patches with inactive reviewers:
+  <table {{ table_attrs }}>
+    <thead>
+      <tr>
+        <th>Bug</th><th>Summary</th><th>Patches</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for i, (bugid, summary, revisions) in enumerate(data) -%}
+      <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+        <td {% if bugid in no_manager %}style="background:red;"{% endif %}>
+          <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+        </td>
+        <td>
+          {{ summary | e }}
+        </td>
+        <td>
+          <ul>
+            {% for rev in revisions -%}
+            <li><a href="https://phabricator.services.mozilla.com/D{{ rev['rev_id'] }}">D{{ rev['rev_id'] }}</a></li>
+            {% endfor -%}
+          </ul>
+        </td>
+      </tr>
+      {% endfor -%}
+    </tbody>
+  </table>
+</p>

--- a/templates/inactive_reviewer_needinfo.txt
+++ b/templates/inactive_reviewer_needinfo.txt
@@ -1,0 +1,19 @@
+The bug has {{ plural('a patch that is', revisions, 'patches that are') }} waiting for review from an inactive reviewer:
+
+| ID  | Title |  Author | Inactive Reviewer |
+| --- | :---- |  ------ | ----------------- |
+{% for rev in revisions -%}
+{% for reviewer in rev['reviewers'] -%}
+{% if rev['reviewers'][0] == reviewer -%}
+| [D{{ rev['rev_id'] }}](https://phabricator.services.mozilla.com/D{{ rev['rev_id'] }}) |  {{ rev['title'] | e }} | [{{ rev['author']['nick'] }}](https://bugzilla.mozilla.org/user_profile?user_id={{ rev['author']['id'] }})  |
+{%- else -%}
+| | | |
+{%- endif -%}
+
+[{{ reviewer['phab_username'] }}](https://phabricator.services.mozilla.com/p/{{ reviewer['phab_username'] }}/) |
+{% endfor -%}
+{% endfor %}
+
+:{{ nicknames }}, could you please find an active reviewer?
+
+{{ documentation }}

--- a/templates/inactive_reviewer_needinfo.txt
+++ b/templates/inactive_reviewer_needinfo.txt
@@ -14,6 +14,6 @@ The following {{ plural('patch is', revisions, 'patches are') }} waiting for rev
 {% endfor -%}
 {% endfor %}
 
-:{{ nicknames }}, could you please find an active reviewer?
+:{{ nicknames }}, could you please find another reviewer or {% if has_old_patch -%} abandon the patch if it is no longer relevant {%- endif%}?
 
 {{ documentation }}

--- a/templates/inactive_reviewer_needinfo.txt
+++ b/templates/inactive_reviewer_needinfo.txt
@@ -1,7 +1,7 @@
 The following {{ plural('patch is', revisions, 'patches are') }} waiting for review from an inactive reviewer:
 
 | ID  | Title |  Author | Reviewer Status |
-| --- | :---- |  ------ | --------------- |
+| --- | :---- |  ------ | :-------------- |
 {% for rev in revisions -%}
 {% for reviewer in rev['reviewers'] -%}
 {% if rev['reviewers'][0] == reviewer -%}

--- a/templates/inactive_reviewer_needinfo.txt
+++ b/templates/inactive_reviewer_needinfo.txt
@@ -14,6 +14,6 @@ The following {{ plural('patch is', revisions, 'patches are') }} waiting for rev
 {% endfor -%}
 {% endfor %}
 
-:{{ nicknames }}, could you please find another reviewer or {% if has_old_patch -%} abandon the patch if it is no longer relevant {%- endif%}?
+:{{ nicknames }}, could you please find another reviewer {%- if has_old_patch %} or abandon the patch if it is no longer relevant {%- endif%}?
 
 {{ documentation }}

--- a/templates/inactive_reviewer_needinfo.txt
+++ b/templates/inactive_reviewer_needinfo.txt
@@ -1,4 +1,4 @@
-The bug has {{ plural('a patch that is', revisions, 'patches that are') }} waiting for review from an inactive reviewer:
+The following {{ plural('patch is', revisions, 'patches are') }} waiting for review from an inactive reviewer:
 
 | ID  | Title |  Author | Inactive Reviewer |
 | --- | :---- |  ------ | ----------------- |

--- a/templates/inactive_reviewer_needinfo.txt
+++ b/templates/inactive_reviewer_needinfo.txt
@@ -1,7 +1,7 @@
 The following {{ plural('patch is', revisions, 'patches are') }} waiting for review from an inactive reviewer:
 
-| ID  | Title |  Author | Inactive Reviewer |
-| --- | :---- |  ------ | ----------------- |
+| ID  | Title |  Author | Reviewer Status |
+| --- | :---- |  ------ | --------------- |
 {% for rev in revisions -%}
 {% for reviewer in rev['reviewers'] -%}
 {% if rev['reviewers'][0] == reviewer -%}
@@ -10,7 +10,7 @@ The following {{ plural('patch is', revisions, 'patches are') }} waiting for rev
 | | | |
 {%- endif -%}
 
-[{{ reviewer['phab_username'] }}](https://phabricator.services.mozilla.com/p/{{ reviewer['phab_username'] }}/) |
+[{{ reviewer['phab_username'] }}](https://phabricator.services.mozilla.com/p/{{ reviewer['phab_username'] }}/): {{ reviewer["status_note"] }} |
 {% endfor -%}
 {% endfor %}
 


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Resolves #1382

## Autonag wiki page
```wiki
{{AutonagRule
  | Rule name = Bugs with inactive patch reviewers
  | Purpose   = Unblock bugs by identifying patches that are waiting for review from inactive or unavailable reviewers
  | Action    = Needinfo patch authors to find active reviewers
  | Source    = inactive_reviewer.py 
}}
```

## Dry-run
See https://github.com/mozilla/relman-auto-nag/pull/1531#issuecomment-1184712892

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [x] Type annotations added to new functions
- [x] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [x] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
