### PR TITLE
Remove regressor script configuration as the regressor script doesn't exist anymore

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -432,14 +432,6 @@
       "cdenizet@mozilla.com"
     ]
   },
-  "regressor": {
-    "max_days_in_cache": 7,
-    "cc": [
-      "sledru@mozilla.com",
-      "mcastelluccio@mozilla.com",
-      "cdenizet@mozilla.com"
-    ]
-  },
   "survey_sec_bugs": {
     "to_reach_out": [
       "continuation@gmail.com",


### PR DESCRIPTION
It was introduced in e795fea301b5922a4d842c7b8d33bcb3261d918f and removed in dfbdff16e5c74bde062c26767404c23c34c33aac, but the configuration was left there.

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing