### PR TITLE
Support the new `triaged` keyword

### DIFF
--- a/auto_nag/components.py
+++ b/auto_nag/components.py
@@ -26,6 +26,19 @@ class ComponentName(NamedTuple):
 
         return cls(*splitted_name)
 
+    @classmethod
+    def from_bug(cls, bug: dict) -> "ComponentName":
+        """Create an instance from a bug dictionary.
+
+        Args:
+            bug: a dictionary that have product and component keys
+
+        Returns:
+            An instance from the ComponentName class based on the provided bug.
+        """
+
+        return cls(bug["product"], bug["component"])
+
 
 class Components:
     """Bugzilla components"""

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -270,27 +270,6 @@
     ],
     "supervisor_skiplist": ["dcamp@mozilla.com"]
   },
-  "no_severity": {
-    "max-years": 1,
-    "first-step": 2,
-    "second-step": 4,
-    "escalation-first": {
-      "default": {
-        "[0;+∞[": {
-          "supervisor": "self",
-          "days": ["Mon", "Tue", "Wed", "Thu", "Fri"]
-        }
-      }
-    },
-    "escalation-second": {
-      "default": {
-        "[0;+∞[": {
-          "supervisor": "n+1",
-          "days": ["Mon", "Thu"]
-        }
-      }
-    }
-  },
   "p3_p4_p5": {
     "months_lookup": 6
   },

--- a/auto_nag/scripts/to_triage.py
+++ b/auto_nag/scripts/to_triage.py
@@ -79,7 +79,7 @@ class ToTriage(BzCleaner, Nag):
             "include_fields": fields,
             "product": list(prods),
             "component": list(comps),
-            "keywords": "intermittent-failure",
+            "keywords": ["intermittent-failure", "triaged"],
             "keywords_type": "nowords",
             "email2": "wptsync@mozilla.bugs",
             "emailreporter2": "1",
@@ -91,9 +91,6 @@ class ToTriage(BzCleaner, Nag):
             "f2": "flagtypes.name",
             "o2": "notsubstring",
             "v2": "needinfo?",
-            "f3": "bug_severity",
-            "o3": "anyexact",
-            "v3": "--, n/a",
         }
 
         return params

--- a/auto_nag/scripts/workflow/multi_nag.py
+++ b/auto_nag/scripts/workflow/multi_nag.py
@@ -4,9 +4,9 @@
 
 from auto_nag.erroneous_bzmail import check_erroneous_bzmail
 from auto_nag.multinaggers import MultiNaggers
-
-from .no_severity import NoSeverity
-from .p1_no_assignee import P1NoAssignee
+from auto_nag.scripts.workflow.not_triaged import NotTriaged
+from auto_nag.scripts.workflow.p1_no_assignee import P1NoAssignee
+from auto_nag.scripts.workflow.triaged_no_severity import TriagedNoSeverity
 
 # from .p1_no_activity import P1NoActivity
 # from .p2_no_activity import P2NoActivity
@@ -16,8 +16,9 @@ from .p1_no_assignee import P1NoAssignee
 class WorkflowMultiNag(MultiNaggers):
     def __init__(self):
         super(WorkflowMultiNag, self).__init__(
-            NoSeverity("first"),
-            NoSeverity("second"),
+            TriagedNoSeverity(),
+            NotTriaged("first"),
+            NotTriaged("second"),
             # P1NoActivity(),
             P1NoAssignee(),
             # P2NoActivity(),
@@ -27,9 +28,7 @@ class WorkflowMultiNag(MultiNaggers):
         return "Bugs requiring special attention to help release management"
 
     def title(self):
-        return "{} -- Severity and Priority Flags Alert".format(
-            self.date.strftime("%A %b %d")
-        )
+        return "{} -- Triage Alert".format(self.date.strftime("%A %b %d"))
 
 
 if __name__ == "__main__":

--- a/auto_nag/scripts/workflow/triaged_no_severity.py
+++ b/auto_nag/scripts/workflow/triaged_no_severity.py
@@ -1,0 +1,170 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from typing import Dict
+
+from libmozdata import utils as lmdutils
+
+from auto_nag import utils
+from auto_nag.bzcleaner import BzCleaner
+from auto_nag.components import ComponentName
+from auto_nag.escalation import Escalation
+from auto_nag.nag_me import Nag
+from auto_nag.round_robin import RoundRobin
+
+ESCALATION_CONFIG = {
+    "normal": {
+        "[0;+∞[": {
+            "supervisor": "self",
+            "days": ["Mon", "Tue", "Wed", "Thu", "Fri"],
+        },
+    },
+    "high": {
+        "[0;+∞[": {
+            "supervisor": "n+1",
+            "days": ["Mon", "Thu"],
+        },
+    },
+}
+
+
+class TriagedNoSeverity(BzCleaner, Nag):
+    def __init__(
+        self,
+        inactivity_days: int = 3,
+        oldest_bug_days: int = 360,
+        normal_escalation_days: int = 14,
+        high_escalation_days: int = 28,
+    ):
+        """Constructor
+
+        Args:
+            inactivity_days: number of days that a bug should be inactive before
+                being considered.
+            oldest_bug_days: the max number of days since the creation of a bug
+                to be considered.
+            normal_escalation_days: number of days since a bug is triaged to be
+                consider for normal escalation.
+            high_escalation_days: number of days since a bug is triaged to be
+                consider for high escalation.
+        """
+        super(TriagedNoSeverity, self).__init__()
+        self.oldest_bug_days = oldest_bug_days
+        self.escalation = Escalation(
+            self.people,
+            data=ESCALATION_CONFIG,
+            skiplist=utils.get_config("workflow", "supervisor_skiplist", []),
+        )
+        self.round_robin = RoundRobin.get_instance()
+        self.components_skiplist = {
+            ComponentName.from_str(pc)
+            for pc in utils.get_config("workflow", "components_skiplist")
+        }
+
+        self.activity_date = lmdutils.get_date("today", inactivity_days)
+        self.normal_escalation_date = lmdutils.get_date("today", normal_escalation_days)
+        self.high_escalation_date = lmdutils.get_date("today", high_escalation_days)
+
+        # FIXME: This is a workaround to pass the priority to `set_people_to_nag`
+        # without altering the bug object.
+        self.bug_priority: Dict[str, str] = {}
+
+    def description(self):
+        return "Triaged bugs without a severity set"
+
+    def nag_template(self):
+        return self.template()
+
+    def nag_preamble(self):
+        return True
+
+    def has_product_component(self):
+        return True
+
+    def ignore_meta(self):
+        return True
+
+    def columns(self):
+        return ["component", "id", "summary", "triaged_since"]
+
+    def handle_bug(self, bug, data):
+        if (
+            ComponentName.from_bug(bug) in self.components_skiplist
+            or utils.get_last_no_bot_comment_date(bug) > self.activity_date
+        ):
+            return None
+
+        triaged_date = utils.get_last_triaged_date(bug)
+        if triaged_date < self.high_escalation_date:
+            priority = "high"
+        elif triaged_date < self.normal_escalation_date:
+            priority = "normal"
+        else:
+            return None
+
+        bugid = str(bug["id"])
+        data[bugid] = {
+            "triaged_since": utils.get_human_lag(triaged_date),
+        }
+
+        self.bug_priority[bugid] = priority
+        return bug
+
+    def get_mail_to_auto_ni(self, bug):
+        mail, nick = self.round_robin.get(bug, self.date)
+        if mail and nick:
+            return {"mail": mail, "nickname": nick}
+
+        return None
+
+    def set_people_to_nag(self, bug, buginfo):
+        priority = self.bug_priority[buginfo["id"]]
+        if priority == "normal":
+            return bug
+
+        owners = self.round_robin.get(bug, self.date, only_one=False, has_nick=False)
+        real_owner = bug["triage_owner"]
+        self.add_triage_owner(owners, real_owner=real_owner)
+        if not self.add(owners, buginfo, priority=priority):
+            self.add_no_manager(buginfo["id"])
+        return bug
+
+    def get_bz_params(self, date):
+        fields = [
+            "triage_owner",
+            "comments.creator",
+            "comments.creation_time",
+            "history",
+        ]
+        params = {
+            "include_fields": fields,
+            "keywords": "intermittent-failure",
+            "keywords_type": "nowords",
+            "email2": "wptsync@mozilla.bugs",
+            "emailreporter2": "1",
+            "emailtype2": "notequals",
+            "resolution": "---",
+            "f1": "creation_ts",
+            "o1": "greaterthan",
+            "v1": f"-{self.oldest_bug_days}d",
+            "f21": "bug_type",
+            "o21": "equals",
+            "v21": "defect",
+            "f22": "flagtypes.name",
+            "o22": "notequals",
+            "v22": "needinfo?",
+            "f23": "bug_severity",
+            "o23": "anyexact",
+            "v23": "--, n/a",
+            "f24": "keywords",
+            "o24": "anyexact",
+            "v24": "triaged",
+        }
+        self.date = lmdutils.get_date_ymd(date)
+
+        return params
+
+
+if __name__ == "__main__":
+    TriagedNoSeverity().run()

--- a/auto_nag/utils.py
+++ b/auto_nag/utils.py
@@ -560,6 +560,7 @@ def bz_ignore_case(s):
 
 
 def check_product_component(data, bug):
+    """TODO: drop in favour of using ComponentName"""
     prod = bug["product"]
     comp = bug["component"]
     pc = prod + "::" + comp
@@ -643,6 +644,27 @@ def get_last_no_bot_comment_date(bug: dict) -> str:
             return comment["creation_time"]
 
     return bug["comments"][0]["creation_time"]
+
+
+def get_last_triaged_date(bug: dict) -> str:
+    """Get the date when the bug was last triaged.
+
+    Args:
+        bug: the bug dictionary; it must has the history list.
+
+    Returns:
+        The date when the triaged keyword was added. If the bug history does not
+        show the triaged keyword, an exception will be raised.
+    """
+    for entry in reversed(bug["history"]):
+        for field in entry["changes"]:
+            if field["field_name"] == "whiteboard":
+                if "triaged" in field["added"] and "triaged" not in field["removed"]:
+                    return entry["when"]
+
+                break
+
+    raise Exception("The bug is not triaged")
 
 
 def get_sort_by_bug_importance_key(bug):

--- a/templates/not_triaged.html
+++ b/templates/not_triaged.html
@@ -1,0 +1,37 @@
+{% if nag_preamble %}
+<p>
+  <ul>
+    <li><a href="https://firefox-source-docs.mozilla.org/bug-mgmt/policies/triage-bugzilla.html#why-triage">Why triage?</a></li>
+    <li><a href="https://firefox-source-docs.mozilla.org/bug-mgmt/policies/triage-bugzilla.html#what-do-you-triage">What do you triage?</a></li>
+    <li><a href="https://firefox-source-docs.mozilla.org/bug-mgmt/guides/priority.html">Priority definitions</a></li>
+    <li><a href="https://firefox-source-docs.mozilla.org/bug-mgmt/guides/severity.html">Severty definitions</a></li>
+  </ul>
+</p>
+{% endif %}
+
+<p>
+  The following {{ plural('bug has', data, pword='bugs have') }} not triaged for the last {{ extra['nweeks'] }} {{ plural('week', extra['nweeks']) }}:
+</p>
+<table {{ table_attrs }}>
+  <thead>
+    <tr>
+      <th>Component</th><th>Bug</th><th>Summary</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for i, (comp, bugid, summary) in enumerate(data) -%}
+    <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+      <td>
+        {{ comp | e }}
+      </td>
+      <td>
+        <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+      </td>
+      <td>
+        {{ summary | e }}
+        </td>
+    </tr>
+    {% endfor -%}
+  </tbody>
+</table>
+{% if query_url_nag %}<p>See the query on <a href="{{ query_url_nag }}">Bugzilla</a>.</p>{% endif -%}

--- a/templates/not_triaged_needinfo.txt
+++ b/templates/not_triaged_needinfo.txt
@@ -1,4 +1,4 @@
-The severity field is not set for this bug.
+This bug is not triaged.
 :{{ nickname }}, could you have a look please?
 
 {{ documentation }}

--- a/templates/triaged_no_severity.html
+++ b/templates/triaged_no_severity.html
@@ -1,15 +1,21 @@
-{{ nag_preamble }}
+{% if nag_preamble %}
 <p>
-  The following {{ plural('bug has', data, pword='bugs have') }} no Severity field set for the last {{ extra['nweeks'] }} {{ plural('week', extra['nweeks']) }}:
+  <ul>
+    <li><a href="https://firefox-source-docs.mozilla.org/bug-mgmt/guides/severity.html">Severty definitions</a></li>
+  </ul>
+</p>
+{% endif %}
+<p>
+  The following triaged {{ plural('bug has', data, pword='bugs have') }} no Severity field set:
 </p>
 <table {{ table_attrs }}>
   <thead>
     <tr>
-      <th>Component</th><th>Bug</th><th>Summary</th>
+      <th>Component</th><th>Bug</th><th>Summary</th><th>Triaged Since</th>
     </tr>
   </thead>
   <tbody>
-    {% for i, (comp, bugid, summary) in enumerate(data) -%}
+    {% for i, (comp, bugid, summary, triaged_since) in enumerate(data) -%}
     <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
       <td>
         {{ comp | e }}
@@ -19,7 +25,10 @@
       </td>
       <td>
         {{ summary | e }}
-        </td>
+      </td>
+      <td>
+        {{ triaged_since }}
+      </td>
     </tr>
     {% endfor -%}
   </tbody>

--- a/templates/triaged_no_severity_needinfo.txt
+++ b/templates/triaged_no_severity_needinfo.txt
@@ -1,0 +1,4 @@
+The bug was triaged, but the severity field still is not set.
+:{{ nickname }}, could you have a look please?
+
+{{ documentation }}


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
Resolves #1505


## Autonag wiki page
```wiki
{{AutonagRule
  | Rule name = Untriaged bugs
  | Purpose   = Remind triage owners about bugs that are not triaged
  | Action    = Needinfo the triage owners and send reminder emails
  | Source    = to_triage.py 
}}
```


## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [x] Type annotations added to new functions
- [x] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
