### PR TITLE
Add 'Developer Infrastructure' to the list of products considered by autonag

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -61,7 +61,8 @@
       "Testing",
       "Toolkit",
       "Web Compatibility",
-      "WebExtensions"
+      "WebExtensions",
+      "Developer Infrastructure"
     ],
     "log": "/tmp/auto_nag_errors.txt",
     "receiver_list": {

--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -47,6 +47,7 @@
     },
     "products": [
       "Core",
+      "Developer Infrastructure",
       "DevTools",
       "External Software Affecting Firefox",
       "Fenix",
@@ -61,8 +62,7 @@
       "Testing",
       "Toolkit",
       "Web Compatibility",
-      "WebExtensions",
-      "Developer Infrastructure"
+      "WebExtensions"
     ],
     "log": "/tmp/auto_nag_errors.txt",
     "receiver_list": {


### PR DESCRIPTION
## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
