### PR TITLE
[inactive_reviewer] Clarify the needinfo comment

### DIFF
--- a/auto_nag/scripts/inactive_reviewer.py
+++ b/auto_nag/scripts/inactive_reviewer.py
@@ -82,19 +82,18 @@ class InactiveReviewer(BzCleaner):
             for revision in inactive_revs
             for reviewer in revision["reviewers"]
         }
-
-        resigned_count = sum(1 for _, note in reviewers if note == "Resigned")
+        has_resigned = any(note == "Resigned from review" for _, note in reviewers)
 
         if len(reviewers) == 1:
-            if resigned_count == 0:
-                summary = "an inactive reviewer"
-            else:
+            if has_resigned:
                 summary = "a reviewer who resigned from the review"
-        else:
-            if resigned_count == 0:
-                summary = "inactive reviewers"
             else:
+                summary = "an inactive reviewer"
+        else:
+            if has_resigned:
                 summary = "reviewers who are inactive or resigned from the review"
+            else:
+                summary = "inactive reviewers"
 
         comment = self.ni_template.render(
             revisions=inactive_revs,
@@ -215,7 +214,7 @@ class InactiveReviewer(BzCleaner):
     @staticmethod
     def _get_reviewer_status_note(reviewer: dict) -> str:
         if reviewer["is_resigned"]:
-            return "Resigned"
+            return "Resigned from review"
 
         status = reviewer["info"]["status"]
         if status == UserStatus.UNAVAILABLE:

--- a/templates/inactive_reviewer_needinfo.txt
+++ b/templates/inactive_reviewer_needinfo.txt
@@ -1,4 +1,4 @@
-The following {{ plural('patch is', revisions, 'patches are') }} waiting for review from an inactive reviewer:
+The following {{ plural('patch is', revisions, 'patches are') }} waiting for review from {{ reviewers_status_summary }}:
 
 | ID  | Title |  Author | Reviewer Status |
 | --- | :---- |  ------ | :-------------- |


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Resolves #1553

## Dry-run

### Example 1

The following patch is waiting for review from a reviewer who resigned from the review:

| ID  | Title |  Author | Reviewer Status |
| --- | :---- |  ------ | :-------------- |
| [D71652](https://phabricator.services.mozilla.com/D71652) |  Bug 1624907 - Split tree.css into shadow and non-shadow stylesheets. | [ntim](https://bugzilla.mozilla.org/user_profile?user_id=445472)  |[dao](https://phabricator.services.mozilla.com/p/dao/): Resigned |


:ntim, could you please find another reviewer or abandon the patch if it is no longer relevant?

For more information, please visit [auto_nag documentation](https://wiki.mozilla.org/Release_Management/autonag#inactive_reviewer.py).





### Example 2

The following patch is waiting for review from an inactive reviewer:

| ID  | Title |  Author | Reviewer Status |
| --- | :---- |  ------ | :-------------- |
| [D131230](https://phabricator.services.mozilla.com/D131230) |  Bug 1741379 - set &#39;Mach Vendor &amp; Updatebot&#39; as Bugzilla component for related files. r=tom | [aryx](https://bugzilla.mozilla.org/user_profile?user_id=258347)  |[tom](https://phabricator.services.mozilla.com/p/tom/): Inactive |


:aryx, could you please find another reviewer or abandon the patch if it is no longer relevant?

For more information, please visit [auto_nag documentation](https://wiki.mozilla.org/Release_Management/autonag#inactive_reviewer.py).





## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
