### PR TITLE
[inactive_ni_pending ] Clarify the comment when clear a needinfo

### DIFF
--- a/auto_nag/scripts/inactive_ni_pending.py
+++ b/auto_nag/scripts/inactive_ni_pending.py
@@ -245,8 +245,8 @@ class InactiveNeedinfoPending(BzCleaner):
                 "comment": {
                     "body": (
                         f'Clear { plural("a needinfo that is", bug["inactive_ni"], "needinfos that are") } pending on { plural("an inactive user", users_num, "inactive users") }.'
-                        "\n\nSince inactive users most likely will not respond; "
-                        "if the missed information is essential and cannot be collected another way, "
+                        "\n\nInactive users most likely will not respond; "
+                        "if the missing information is essential and cannot be collected another way, "
                         "the bug maybe should be closed as `INCOMPLETE`."
                     ),
                 },

--- a/auto_nag/scripts/inactive_ni_pending.py
+++ b/auto_nag/scripts/inactive_ni_pending.py
@@ -243,7 +243,12 @@ class InactiveNeedinfoPending(BzCleaner):
             autofix = {
                 "flags": self._clear_inactive_ni_flags(bug),
                 "comment": {
-                    "body": f'Clear { plural("a needinfo that is", bug["inactive_ni"], "needinfos that are") } pending on { plural("an inactive user", users_num, "inactive users") }.',
+                    "body": (
+                        f'Clear { plural("a needinfo that is", bug["inactive_ni"], "needinfos that are") } pending on { plural("an inactive user", users_num, "inactive users") }.'
+                        "\n\nSince inactive users most likely will not respond; "
+                        "if the missed information is essential and cannot be collected another way, "
+                        "the bug maybe should be closed as `INCOMPLETE`."
+                    ),
                 },
             }
 


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Resolves #1523


## Example from the dry-run

Clear a needinfo that is pending on an inactive user.

Since inactive users most likely will not respond; if the missed information is essential and cannot be collected another way, the bug maybe should be closed as `INCOMPLETE`.

For more information, please visit [auto_nag documentation](https://wiki.mozilla.org/Release_Management/autonag#inactive_ni_pending.py).


## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
