### PR TITLE
Add an "deprecation" reminder type

### DIFF
--- a/auto_nag/scripts/reminder.py
+++ b/auto_nag/scripts/reminder.py
@@ -11,7 +11,7 @@ from libmozdata.bugzilla import BugzillaUser
 from auto_nag import utils
 from auto_nag.bzcleaner import BzCleaner
 
-REMINDER_TYPES = ["test", "pref", "disclosure"]
+REMINDER_TYPES = ["test", "pref", "disclosure", "deprecation"]
 DATE_MATCH = re.compile(
     r"\[reminder\-(%s) ([0-9]{4}-[0-9]{1,2}-[0-9]{1,2})\]" % "|".join(REMINDER_TYPES)
 )


### PR DESCRIPTION
~~This can be used when none of the other categories are really what you're using it for.~~
This can be used when one should look into removing a deprecated API/feature.

I have a use case for a reminder: Remind me to look into a deprecated functionality in ~3 months.
The existing categories don't really match this.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
