### PR TITLE
Nag on fuzz blocker bugs

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -62,6 +62,9 @@
     "max_actions": 3,
     "must_run": ["Mon"]
   },
+  "fuzz_blockers": {
+    "must_run": ["Mon"]
+  },
   "patch_closed_bug": {
     "additional_receivers": "rm"
   },

--- a/auto_nag/scripts/fuzz_blockers.py
+++ b/auto_nag/scripts/fuzz_blockers.py
@@ -1,0 +1,41 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from auto_nag.bzcleaner import BzCleaner
+from auto_nag.nag_me import Nag
+
+
+class FuzzBlockers(BzCleaner, Nag):
+    def description(self):
+        return "Bugs that prevent fuzzing from making progress"
+
+    def nag_template(self):
+        return super().template()
+
+    def set_people_to_nag(self, bug, buginfo):
+        persons = [
+            bug["assigned_to"],
+            bug["triage_owner"],
+        ]
+        if not self.add(persons, buginfo):
+            self.add_no_manager(buginfo["id"])
+
+        return bug
+
+    def get_bz_params(self, date):
+        fields = [
+            "triage_owner",
+            "assigned_to",
+        ]
+        return {
+            "include_fields": fields,
+            "bug_status": ["UNCONFIRMED", "NEW", "ASSIGNED", "REOPENED"],
+            "f1": "status_whiteboard",
+            "o1": "substring",
+            "v1": "[fuzzblocker]",
+        }
+
+
+if __name__ == "__main__":
+    FuzzBlockers().run()

--- a/auto_nag/scripts/fuzz_blockers.py
+++ b/auto_nag/scripts/fuzz_blockers.py
@@ -48,7 +48,7 @@ class FuzzBlockers(BzCleaner, Nag):
         """Get whether the bug has a previous comment by this tool"""
         for comment in reversed(bug["comments"]):
             if comment["creator"] == History.BOT and comment["raw_text"].startswith(
-                "This bug prevent fuzzing from making progress."
+                "This bug prevents fuzzing from making progress."
             ):
                 return True
 

--- a/auto_nag/scripts/fuzz_blockers.py
+++ b/auto_nag/scripts/fuzz_blockers.py
@@ -12,6 +12,17 @@ LOW_SEVERITY = ["S3", "normal", "S4", "minor", "trivial", "enhancement"]
 
 
 class FuzzBlockers(BzCleaner, Nag):
+    def __init__(self, waiting_days: int = 3):
+        """Constructor
+
+        Args:
+            waiting_days: number of days to wait after the bug creation before
+                starting to nag.
+        """
+        super().__init__()
+
+        self.waiting_days = waiting_days
+
     def description(self):
         return "Bugs that prevent fuzzing from making progress"
 
@@ -57,6 +68,9 @@ class FuzzBlockers(BzCleaner, Nag):
             "f1": "status_whiteboard",
             "o1": "substring",
             "v1": "[fuzzblocker]",
+            "f2": "creation_ts",
+            "o2": "lessthaneq",
+            "v2": f"-{self.waiting_days}d",
         }
 
 

--- a/runauto_nag_daily.sh
+++ b/runauto_nag_daily.sh
@@ -181,6 +181,9 @@ python -m auto_nag.scripts.tracked_attention --production
 # Needinfo patch authors to find active reviewers
 python -m auto_nag.scripts.inactive_reviewer --production
 
+# Nag on fuzz blocker bugs
+python -m auto_nag.scripts.fuzz_blockers --production
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m auto_nag.log --send

--- a/templates/fuzz_blockers.html
+++ b/templates/fuzz_blockers.html
@@ -1,0 +1,21 @@
+<p>The following {{ plural('bug is', data, pword='bugs are') }} preventing fuzzing from making progress:
+  <table {{ table_attrs }}>
+    <thead>
+      <tr>
+        <th>Bug</th><th>Summary</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for i, (bugid, summary) in enumerate(data) -%}
+      <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+        <td>
+          <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+        </td>
+        <td>
+          {{ summary | e }}
+        </td>
+      </tr>
+      {% endfor -%}
+    </tbody>
+  </table>
+</p>

--- a/templates/fuzz_blockers_needinfo.txt
+++ b/templates/fuzz_blockers_needinfo.txt
@@ -1,0 +1,4 @@
+This bug prevents fuzzing from making progress; however, it has low severity. It is important for fuzz blocker bugs to be addressed in a timely manner (see [here](https://firefox-source-docs.mozilla.org/tools/fuzzing/index.html#fuzz-blockers) why?).
+:{{ nickname }}, could you increase the severity?
+
+{{ documentation }}


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Resolves #1147 

Depends on #1573

## Autonag wiki page
```wiki
{{AutonagRule
  | Rule name = Fuzz blocker bugs
  | Purpose   = Bring attention to bugs that prevent fuzzing from making progress
  | Action    = Send weekly reminder emails and suggest increasing the severity when it is low.
  | Source    = fuzz_blockers.py 
}}
```

## Dry-run

```
2022-07-26 22:17:17,313 - INFO - Run tool fuzz_blockers.py
2022-07-26 22:17:23,470 - INFO - Tool fuzz_blockers.py has finished.
```

### Email

<details>
<summary>Click to expand the dry-run output!</summary><br>

<p>The following bugs are preventing fuzzing from making progress:
<table style="border:1px solid black;border-collapse:collapse;" border="1">
<thead>
<tr>
<th>Bug</th><th>Summary</th>
</tr>
</thead>
<tbody>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1778549">1778549</a>
</td>
<td>
Hit MOZ_CRASH(Bad `packing`.) at /dom/canvas/WebGLFormats.cpp:685
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1778144">1778144</a>
</td>
<td>
OOM when specifying large `first` index for drawArrays
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1777569">1777569</a>
</td>
<td>
AddressSanitizer failed to allocate 0x200002000 (8589942784) bytes of LargeMmapAllocator (error code: 1455) [@ __asan::CheckUnwind]
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1771253">1771253</a>
</td>
<td>
Hit MOZ_CRASH(called `Result::unwrap()` on an `Err` value: Custom(&#34;Invalid bits for ShaderStages&#34;)) at gfx/wgpu_bindings/src/server.rs:514
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1769798">1769798</a>
</td>
<td>
ASan allocator does not return NULL on Windows
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1768190">1768190</a>
</td>
<td>
Assertion failure: [GFX1]: void mozilla::gl::GLContext::raw_fDrawArrays(GLenum, GLint, GLsizei): Generated unexpected GL_INVALID_OPERATION error, at /gfx/2d/Logging.h:754
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1766668">1766668</a>
</td>
<td>
Assertion failure: mState == kJsepStateStable, at /dom/media/webrtc/jsep/JsepSessionImpl.cpp:2403
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1743948">1743948</a>
</td>
<td>
Hit MOZ_CRASH(bug: this is an unexpected case - please open a bug and talk to #gfx team!) at gfx/wr/webrender/src/spatial_tree.rs:957
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1735444">1735444</a>
</td>
<td>
Assertion failure: false (item should have finite clip with respect to aASR), at /builds/worker/checkouts/gecko/layout/painting/nsDisplayList.cpp:2594
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1673677">1673677</a>
</td>
<td>
Assertion failure: !aWM.IsOrthogonalTo(wm), at src/layout/generic/nsIFrameInlines.h:157
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1658818">1658818</a>
</td>
<td>
Startup crash on ASan builds
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1648570">1648570</a>
</td>
<td>
Hit MOZ_CRASH(This is unsafe! Fix the caller!) at /builds/worker/checkouts/gecko/dom/events/EventDispatcher.cpp:810
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1609775">1609775</a>
</td>
<td>
AddressSanitizer: SEGV /builds/worker/workspace/build/src/ipc/glue/MessageLink.cpp:151:5 in mozilla::ipc::ProcessLink::SendMessage(IPC::Message*)
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1590940">1590940</a>
</td>
<td>
Crash [@ mozilla::gfx::VRPuppetCommandBuffer::Get]
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1588954">1588954</a>
</td>
<td>
Assertion failure: aContainingBlockISize &gt;= 0 (inline-size less than zero), at src/layout/generic/nsFrame.cpp:6581
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1573528">1573528</a>
</td>
<td>
Assertion failure: NS_IsMainThread(), at /builds/worker/workspace/build/src/obj-firefox/dist/include/mozilla/ClearOnShutdown.h:95
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1548930">1548930</a>
</td>
<td>
Assertion failure: localTransform.IsIdentity(), at src/gfx/layers/composite/AsyncCompositionManager.cpp:505
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1472024">1472024</a>
</td>
<td>
Assertion failure: false (MOZ_ASSERT_UNREACHABLE: Bogus row index?), at src/layout/tables/nsCellMap.cpp:361
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1470535">1470535</a>
</td>
<td>
MacOS AddressSanitizer tracebacks don&#39;t include source:line information.
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1467769">1467769</a>
</td>
<td>
Use-of-uninitialized-value &#183; clamp_float
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1467519">1467519</a>
</td>
<td>
Assertion failure: nscoord((1 &lt;&lt; 30) - 1) != aContainingBlockBSize || !aCoord.HasPercent() (unexpected containing block block-size), at nsLayoutUtils.cpp:5630
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1463977">1463977</a>
</td>
<td>
Assertion failure: aComputedBSize &gt;= 0 (Invalid computed block-size!), at layout/generic/ReflowInput.cpp:308
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1442796">1442796</a>
</td>
<td>
crash at null in [@ cubeb::stream::{{impl}}::drop&lt;u8&gt;]
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1441601">1441601</a>
</td>
<td>
Assertion failure: mExtraForgetSkippableCalls == 0 (Forget to reset extra forget skippable calls?), at /home/worker/workspace/build/src/dom/base/nsJSEnvironment.cpp:1336
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1441259">1441259</a>
</td>
<td>
crash near null in [@ attachVRController]
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1440611">1440611</a>
</td>
<td>
some linux crashes missing symbolication
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1403656">1403656</a>
</td>
<td>
stack overflow during reflow, with infinite recursion in ProcessReflowCommands-&gt;DidDoReflow-&gt;DoFlushPendingNotifications
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1386340">1386340</a>
</td>
<td>
ASSERTION: nsToolkitProfileService::Init failed!: &#39;Error&#39; (start up hang)
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1140043">1140043</a>
</td>
<td>
&#34;Assertion failure: applyState.mWidth.mConsumed == applyState.mWidth.mAvailable (Unprocessed justification width)&#34;
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1127525">1127525</a>
</td>
<td>
&#34;Assertion failure: !isIncrementalGCInProgress()&#34; with gczeal(4), verifyprebarriers()
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1115005">1115005</a>
</td>
<td>
Consider adding more !cx-&gt;isExceptionPending() asserts
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=847699">847699</a>
</td>
<td>
Crash extending the selection after Find [@ nsRange::UnregisterCommonAncestor]
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=760879">760879</a>
</td>
<td>
&#34;ASSERTION: aOffset out of range&#34; with contentEditable, forwardDelete
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=671152">671152</a>
</td>
<td>
ASSERTION: null node passed to IsTextNode() + ASSERTION: selection could not be collapsed after undo of deletetext.
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=507876">507876</a>
</td>
<td>
minidump_stackwalk can&#39;t handle stack overflow crash (Breakpad generating bad minidump?)
</td>
</tr>
</tbody>
</table>

</details>

### Example of needinfo comment 

<details>
<summary>Click to expand the dry-run output!</summary><br>

This bug prevents fuzzing from making progress; however, it has low severity. It is important for fuzz blocker bugs to be addressed in a timely manner (see [here](https://firefox-source-docs.mozilla.org/tools/fuzzing/index.html#fuzz-blockers) why?).
:gsvelto, could you increase the severity?

For more information, please visit [auto_nag documentation](https://wiki.mozilla.org/Release_Management/autonag#fuzz_blockers.py).


</details>


## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [x] Type annotations added to new functions
- [x] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [x] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
