### PR TITLE
Support using nomail Bugzilla account

### DIFF
--- a/auto_nag/bzcleaner.py
+++ b/auto_nag/bzcleaner.py
@@ -566,7 +566,7 @@ class BzCleaner(object):
         """Autofix the bugs according to what is returned by get_autofix_change"""
         ni_changes = self.set_needinfo()
         change = self.get_autofix_change()
-        put_cls = SilentBugzilla if self.no_bugmail else Bugzilla
+        bugzilla_cls = SilentBugzilla if self.no_bugmail else Bugzilla
 
         if not ni_changes and not change:
             return bugs
@@ -600,7 +600,7 @@ class BzCleaner(object):
             for bugid, ch in new_changes.items():
                 added = False
                 for _ in range(max_retries):
-                    failures = put_cls([str(bugid)]).put(ch)
+                    failures = bugzilla_cls([str(bugid)]).put(ch)
                     if failures:
                         time.sleep(1)
                     else:

--- a/auto_nag/bzcleaner.py
+++ b/auto_nag/bzcleaner.py
@@ -27,10 +27,17 @@ class SilentBugzilla(Bugzilla):
 
 
 class BzCleaner(object):
+    """
+    Attributes:
+        no_bugmail: If `True`, a token for an account that does not trigger
+            bugmail will be used when performing `PUT` actions on Bugzilla.
+    """
+
+    no_bugmail: bool = False
+
     def __init__(self):
         super(BzCleaner, self).__init__()
         self._set_tool_name()
-        self.no_bugmail = False
         self.has_autofix = False
         self.autofix_changes = {}
         self.quota_actions = defaultdict(list)

--- a/auto_nag/config.py
+++ b/auto_nag/config.py
@@ -19,10 +19,12 @@ class MyConfig(config.Config):
         else:
             with open(MyConfig.PATH) as In:
                 self.conf = json.load(In)
-            if "bz_api_key" not in self.conf:
-                raise Exception("Your config.json file must contain a Bugzilla token")
-            if "bz_api_key_nomail" not in self.conf:
-                self.conf["bz_api_key_nomail"] = self.conf["bz_api_key"]
+
+        if "bz_api_key" not in self.conf:
+            raise Exception("Your config.json file must contain a Bugzilla token")
+
+        if "bz_api_key_nomail" not in self.conf:
+            self.conf["bz_api_key_nomail"] = self.conf["bz_api_key"]
 
     def get(self, section, option, default=None, type=str):
         if section == "Bugzilla":

--- a/auto_nag/config.py
+++ b/auto_nag/config.py
@@ -19,15 +19,17 @@ class MyConfig(config.Config):
         else:
             with open(MyConfig.PATH) as In:
                 self.conf = json.load(In)
-                if not self.conf.get("bz_api_key", None):
-                    raise Exception(
-                        "Your config.json file must contain a Bugzilla token"
-                    )
+            if "bz_api_key" not in self.conf:
+                raise Exception("Your config.json file must contain a Bugzilla token")
+            if "bz_api_key_nomail" not in self.conf:
+                self.conf["bz_api_key_nomail"] = self.conf["bz_api_key"]
 
     def get(self, section, option, default=None, type=str):
         if section == "Bugzilla":
             if option == "token":
                 return self.conf["bz_api_key"]
+            if option == "nomail-token":
+                return self.conf["bz_api_key_nomail"]
         elif section == "User-Agent":
             return "relman-auto-nag"
         return default

--- a/auto_nag/config.py
+++ b/auto_nag/config.py
@@ -25,7 +25,7 @@ class MyConfig(config.Config):
 
         if "bz_api_key_nomail" not in self.conf:
             raise Exception(
-                "Your config.json file must contain a Bugzilla token for account that doesn't trigger bugmail"
+                "Your config.json file must contain a Bugzilla token for an account that doesn't trigger bugmail (for testing, you can use the same token as bz_api_key)"
             )
 
     def get(self, section, option, default=None, type=str):

--- a/auto_nag/config.py
+++ b/auto_nag/config.py
@@ -15,7 +15,7 @@ class MyConfig(config.Config):
     def __init__(self):
         super(MyConfig, self).__init__()
         if not os.path.exists(MyConfig.PATH):
-            self.conf = {"bz_api_key": ""}
+            self.conf = {"bz_api_key": "", "bz_api_key_nomail": ""}
         else:
             with open(MyConfig.PATH) as In:
                 self.conf = json.load(In)
@@ -24,7 +24,9 @@ class MyConfig(config.Config):
             raise Exception("Your config.json file must contain a Bugzilla token")
 
         if "bz_api_key_nomail" not in self.conf:
-            self.conf["bz_api_key_nomail"] = self.conf["bz_api_key"]
+            raise Exception(
+                "Your config.json file must contain a Bugzilla token for account that doesn't trigger bugmail"
+            )
 
     def get(self, section, option, default=None, type=str):
         if section == "Bugzilla":

--- a/auto_nag/scripts/closed_dupeme.py
+++ b/auto_nag/scripts/closed_dupeme.py
@@ -6,6 +6,8 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class DupeMe(BzCleaner):
+    no_bugmail = True
+
     def description(self):
         return "Closed bugs with dupeme keyword"
 

--- a/auto_nag/scripts/leave_open.py
+++ b/auto_nag/scripts/leave_open.py
@@ -6,6 +6,8 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class LeaveOpen(BzCleaner):
+    no_bugmail = True
+
     def description(self):
         return "Closed bugs with leave-open keyword"
 

--- a/auto_nag/scripts/stalled.py
+++ b/auto_nag/scripts/stalled.py
@@ -6,6 +6,8 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class Stalled(BzCleaner):
+    no_bugmail = True
+
     def description(self):
         return "Closed bugs with stalled keyword"
 

--- a/auto_nag/scripts/summary_meta_missing.py
+++ b/auto_nag/scripts/summary_meta_missing.py
@@ -6,9 +6,7 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class MetaSummaryMissing(BzCleaner):
-    def __init__(self):
-        super().__init__()
-        self.no_bugmail = True
+    no_bugmail = True
 
     def description(self):
         return "Bugs without the meta keyword but with [meta] in the title"

--- a/auto_nag/scripts/summary_meta_missing.py
+++ b/auto_nag/scripts/summary_meta_missing.py
@@ -6,6 +6,10 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class MetaSummaryMissing(BzCleaner):
+    def __init__(self):
+        super().__init__()
+        self.no_bugmail = True
+
     def description(self):
         return "Bugs without the meta keyword but with [meta] in the title"
 


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Resolves #1404 

## Usage

To put changes without triggering bugmails, the tool should add ` self.no_bugmail = True` in its contractor to overwrite the field from `BzCleaner`.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [x] Type annotations added to new functions
- [X] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [X] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
