### PR TITLE
Allow needinfo bugs selectively when there are no individual auto-fixes

### DIFF
--- a/auto_nag/bzcleaner.py
+++ b/auto_nag/bzcleaner.py
@@ -567,9 +567,9 @@ class BzCleaner(object):
         if not self.has_individual_autofix(change):
             bugids = self.get_list_bugs(bugs)
             for bugid in bugids:
-                new_changes[bugid] = utils.merge_bz_changes(
-                    change, ni_changes.get(bugid, {})
-                )
+                mrg = utils.merge_bz_changes(change, ni_changes.get(bugid, {}))
+                if mrg:
+                    new_changes[bugid] = mrg
         else:
             change = {str(k): v for k, v in change.items()}
             bugids = set(change.keys()) | set(ni_changes.keys())


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Currently, if the `get_mail_to_auto_ni()` method returns `None` and the bug is not filtered out, autonag will try to put empty changes on Bugzilla. Example:

```
2022-07-26 22:01:23,389 - INFO - The bugs: 1127525
 will be autofixed with:
{}
```


## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
