### PR TITLE
Bump days lookup for the spambug tool to 7 days

### DIFF
--- a/auto_nag/scripts/configs/tools.json
+++ b/auto_nag/scripts/configs/tools.json
@@ -410,7 +410,7 @@
   "spambug": {
     "max_days_in_cache": 7,
     "additional_receivers": ["glob@mozilla.com", "mhoye@mozilla.com"],
-    "days_lookup": 3,
+    "days_lookup": 7,
     "confidence_threshold": 0.95,
     "cc": []
   },


### PR DESCRIPTION
This will make it easier to catch bugs that are spam but filed as security bugs and are moved a few days after they are filed out from security.

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
