### PR TITLE
[fuzz_blockers] Exclude old bugs

### DIFF
--- a/auto_nag/scripts/fuzz_blockers.py
+++ b/auto_nag/scripts/fuzz_blockers.py
@@ -71,6 +71,9 @@ class FuzzBlockers(BzCleaner, Nag):
             "f2": "creation_ts",
             "o2": "lessthaneq",
             "v2": f"-{self.waiting_days}d",
+            "f3": "creation_ts",
+            "o3": "greaterthan",
+            "v3": "2021-07-01",
         }
 
 


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
Following up on #1564

Temporary exclude old bugs to avoid adding noise if old bugs are no longer relevant. We could remove the date limitation after reviewing old bugs by the fuzzing team.

## Dry-run

<p>The following bugs are preventing fuzzing from making progress:
<table style="border:1px solid black;border-collapse:collapse;" border="1">
<thead>
<tr>
<th>Bug</th><th>Summary</th>
</tr>
</thead>
<tbody>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1781961">1781961</a>
</td>
<td>
Large allocation [@ wgpu_core::device::Device$LT$A$GT$::create_bind_group_layout]
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1778549">1778549</a>
</td>
<td>
Hit MOZ_CRASH(Bad `packing`.) at /dom/canvas/WebGLFormats.cpp:685
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1778144">1778144</a>
</td>
<td>
OOM when specifying large `first` index for drawArrays
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1777569">1777569</a>
</td>
<td>
AddressSanitizer failed to allocate 0x200002000 (8589942784) bytes of LargeMmapAllocator (error code: 1455) [@ __asan::CheckUnwind]
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1771253">1771253</a>
</td>
<td>
Hit MOZ_CRASH(called `Result::unwrap()` on an `Err` value: Custom(&#34;Invalid bits for ShaderStages&#34;)) at gfx/wgpu_bindings/src/server.rs:514
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1768190">1768190</a>
</td>
<td>
Assertion failure: [GFX1]: void mozilla::gl::GLContext::raw_fDrawArrays(GLenum, GLint, GLsizei): Generated unexpected GL_INVALID_OPERATION error, at /gfx/2d/Logging.h:754
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1766668">1766668</a>
</td>
<td>
Assertion failure: mState == kJsepStateStable, at /dom/media/webrtc/jsep/JsepSessionImpl.cpp:2403
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1743948">1743948</a>
</td>
<td>
Hit MOZ_CRASH(bug: this is an unexpected case - please open a bug and talk to #gfx team!) at gfx/wr/webrender/src/spatial_tree.rs:957
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1735444">1735444</a>
</td>
<td>
Assertion failure: false (item should have finite clip with respect to aASR), at /builds/worker/checkouts/gecko/layout/painting/nsDisplayList.cpp:2594
</td>
</tr>
</tbody>
</table>
## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
