### PR TITLE
Revert "[fuzz_blockers] Exclude old bugs (#1584)"

### DIFF
--- a/auto_nag/scripts/fuzz_blockers.py
+++ b/auto_nag/scripts/fuzz_blockers.py
@@ -71,9 +71,6 @@ class FuzzBlockers(BzCleaner, Nag):
             "f2": "creation_ts",
             "o2": "lessthaneq",
             "v2": f"-{self.waiting_days}d",
-            "f3": "creation_ts",
-            "o3": "greaterthan",
-            "v3": "2021-07-01",
         }
 
 


### PR DESCRIPTION
This reverts commit c5727e01c8a34afab5939e4453178e50599b5484.

Resolves #1586 


From @pyoor in the [fuzzing room on Matrix](https://matrix.to/#/!fKDCypxwedIOzgALgc:mozilla.org/$E7nsJVb7pYY0ymO_DVohOChIDuN_faAU8iwo3dztQlI?via=mozilla.org&via=matrix.org&via=envs.net):
> I went through all of the open fuzzblockers and either closed the bug, removed the fuzzblocker entry, or verified that it is still a fuzzblock
> I have a few that still exist but the testcase no longer reproduces and I'm in the process of getting a new testcase
> but otherwise we should be good with the current list

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
