### PR TITLE
Needinfo more than one author to fill regressed_by

### DIFF
--- a/auto_nag/scripts/fuzzing_bisection_without_regressed_by.py
+++ b/auto_nag/scripts/fuzzing_bisection_without_regressed_by.py
@@ -85,6 +85,8 @@ class FuzzingBisectionWithoutRegressedBy(BzCleaner):
                 nicknames = [":" + user["nickname"] for user in bug["needinfo_targets"]]
                 ni_comment = ni_template.render(
                     nicknames=utils.english_list(nicknames),
+                    authors_count=len(nicknames),
+                    is_assignee=not utils.is_no_assignee(bug["assigned_to"]),
                     plural=utils.plural,
                     documentation=docs,
                 )

--- a/templates/fuzzing_bisection_without_regressed_by_needinfo.txt
+++ b/templates/fuzzing_bisection_without_regressed_by_needinfo.txt
@@ -1,3 +1,5 @@
-{{ nicknames }}, since this bug contains a bisection range, could you fill (if possible) the regressed_by field?
+This bug contains a bisection range, and the `Regressed by` field is still not filled.
+
+{{ nicknames }}, {% if not is_assignee -%} since you are the {{ plural("author", authors_count) }} of the changes in the range, {% endif -%} if possible, could you fill the `Regressed by` field and investigate this regression?
 
 {{ documentation }}

--- a/templates/fuzzing_bisection_without_regressed_by_needinfo.txt
+++ b/templates/fuzzing_bisection_without_regressed_by_needinfo.txt
@@ -1,2 +1,3 @@
-:{{ nickname }}, since this bug contains a bisection range, could you fill (if possible) the regressed_by field?
+{{ nicknames }}, since this bug contains a bisection range, could you fill (if possible) the regressed_by field?
+
 {{ documentation }}


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Resolves #1475 

**Note:** reviewing commit by commit will be clearer

## Dry-run

```
2022-08-05 00:00:21,777 - INFO - Run tool fuzzing_bisection_without_regressed_by.py
2022-08-05 00:00:27,234 - WARNING - No bzmail for Bogdan Tara <btara@xxxx.xxx> in bug 1655511
2022-08-05 00:00:28,715 - WARNING - No bzmail for sotaro <sotaro.ikeda.g@xxxx.xxx> in bug 1716829
2022-08-05 00:00:29,101 - WARNING - No bzmail for Coroiu Cristina <ccoroiu@xxxx.xxx> in bug 1673123
2022-08-05 00:00:39,550 - WARNING - No bzmail for Xidorn Quan <me@xxxx.xxx> in bug 1780676
2022-08-05 00:00:39,731 - WARNING - No bzmail for Henrik Skupin <mail@xxxx.xxx> in bug 1729829
2022-08-05 00:00:39,732 - WARNING - No bzmail for Mats Palmgren <mats@xxxx.xxx> in bug 1729829
2022-08-05 00:00:45,957 - WARNING - No bzmail for Henrik Skupin <mail@xxxx.xxx> in bug 1735444
2022-08-05 00:00:45,957 - WARNING - No bzmail for Mats Palmgren <mats@xxxx.xxx> in bug 1735444
2022-08-05 00:00:54,961 - INFO - Tool fuzzing_bisection_without_regressed_by.py has finished.
```

<details>
<summary>Click to expand the dry-run output!</summary><br>

<p>The following bugs contain a fuzzing bisection but regressed_by is empty:
<table style="border:1px solid black;border-collapse:collapse;" border="1">
<thead>
<tr>
<th>Bug</th><th>Summary</th>
</tr>
</thead>
<tbody>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1780676">1780676</a>
</td>
<td>
Assertion failure: positionedParts &amp;&amp; positionedParts-&gt;Contains(aFrame) (Asked to unregister a positioned table part that wasn&#39;t registered), at /builds/worker/checkouts/gecko/layout/tables/nsTableFrame.cpp:308
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1735444">1735444</a>
</td>
<td>
Assertion failure: false (item should have finite clip with respect to aASR), at /builds/worker/checkouts/gecko/layout/painting/nsDisplayList.cpp:2594
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1729829">1729829</a>
</td>
<td>
Hit MOZ_CRASH(BUG: Unable to find glyph key cache!) at gfx/wr/webrender/src/glyph_cache.rs:118
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1716829">1716829</a>
</td>
<td>
Large allocation [@ webrender::api_resources::ApiResources::update]
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1673123">1673123</a>
</td>
<td>
Assertion failure: GetOutputRectInRect(aRect).Contains(aRect), at src/gfx/2d/FilterNodeSoftware.cpp:611
</td>
</tr>
<tr >
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1655511">1655511</a>
</td>
<td>
AddressSanitizer: SEGV /builds/worker/checkouts/gecko/docshell/shistory/ChildSHistory.cpp:74:13 in mozilla::dom::ChildSHistory::Index()
</td>
</tr>
</tbody>
</table>


</details>


## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [x] Type annotations added to new functions
- [x] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
