### PR TITLE
[regression_set_status_flags] Fix setting the `regression` keyword

### DIFF
--- a/auto_nag/scripts/regression_set_status_flags.py
+++ b/auto_nag/scripts/regression_set_status_flags.py
@@ -168,12 +168,12 @@ class RegressionSetStatusFlags(BzCleaner):
             regressor = bugs[bugid]["regressed_by"]
             self.status_changes[bugid]["comment"] = {
                 "body": f"{self.description()} {regressor}",
-                "keywords": {"add": ["regression"]},
                 # if the regressing bug is private (security or otherwise
                 # confidential), don't leak its number through our comment (the
                 # regressed_by field is not public in that case)
                 "is_private": bool(data[regressor].get("groups")),
             }
+            self.status_changes[bugid]["keywords"] = {"add": ["regression"]}
 
         return filtered_bugs
 

--- a/auto_nag/tests/test_regression_set_status_flags.py
+++ b/auto_nag/tests/test_regression_set_status_flags.py
@@ -104,6 +104,14 @@ class TestSetStatusFlags(unittest.TestCase):
                 "cf_status_firefox_esr2",
                 "cf_status_firefox_esr3",
                 "comment",
+                "keywords",
+            ],
+        )
+        self.assertEqual(
+            sorted(r.status_changes["1111"]["comment"]),
+            [
+                "body",
+                "is_private",
             ],
         )
         self.assertEqual(r.status_changes["1111"]["cf_status_firefox2"], "unaffected")


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Fixes #1635

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
