### PR TITLE
[tracked_attention] Drop unnecessary comment link

### DIFF
--- a/auto_nag/scripts/tracked_attention.py
+++ b/auto_nag/scripts/tracked_attention.py
@@ -159,8 +159,7 @@ class TrackedAttention(BzCleaner):
             self.autofix_changes[bugid] = {
                 "comment": {
                     "body": (
-                        f"This is a reminder regarding [comment #{comment_num}]"
-                        f"(https://bugzilla.mozilla.org/show_bug.cgi?id={bugid}#{comment_num})!\n\n"
+                        f"This is a reminder regarding comment #{comment_num}!\n\n"
                         f"The bug is marked as { utils.english_list(tracking_statuses) }. "
                         "We have limited time to fix this, "
                         f"the soft freeze is { self.soft_freeze_delta }. "


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Similar to #1634

This will fix the broken link to the comment (it is missing the `c` before the comment number).
Example: https://bugzilla.mozilla.org/show_bug.cgi?id=1788174#c13


## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
