### PR TITLE
Clear the severity for bugs with old-style severity values

### DIFF
--- a/auto_nag/scripts/severity_migration.py
+++ b/auto_nag/scripts/severity_migration.py
@@ -94,9 +94,6 @@ class SeverityMigration(BzCleaner):
     def ignore_meta(self):
         return False
 
-    def has_default_products(self):
-        return False
-
     def has_access_to_sec_bugs(self):
         return True
 

--- a/auto_nag/scripts/severity_migration.py
+++ b/auto_nag/scripts/severity_migration.py
@@ -81,6 +81,18 @@ class SeverityMigration(BzCleaner):
             },
         }
 
+    def filter_no_nag_keyword(self):
+        return False
+
+    def ignore_meta(self):
+        return False
+
+    def has_default_products(self):
+        return False
+
+    def has_access_to_sec_bugs(self):
+        return True
+
     def get_bz_params(self, date):
         params = {
             "include_fields": ["product", "component"],

--- a/auto_nag/scripts/severity_migration.py
+++ b/auto_nag/scripts/severity_migration.py
@@ -16,8 +16,6 @@ class SeverityMigration(BzCleaner):
     are dropped.
     """
 
-    no_bugmail = True
-
     def __init__(self):
         super().__init__()
         self.team_bugs_count = {}

--- a/auto_nag/scripts/severity_migration.py
+++ b/auto_nag/scripts/severity_migration.py
@@ -104,6 +104,9 @@ class SeverityMigration(BzCleaner):
             "bug_severity": {"blocker", "critical", "major"},
             "f1": "cf_crash_signature",
             "o1": "isempty",
+            "f2": "product",
+            "o2": "notequals",
+            "v2": "Testing",
         }
 
         return params

--- a/auto_nag/scripts/severity_migration.py
+++ b/auto_nag/scripts/severity_migration.py
@@ -1,0 +1,97 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+from libmozdata.bugzilla import BugzillaProduct
+
+from auto_nag.bzcleaner import BzCleaner
+from auto_nag.components import ComponentName
+
+
+class SeverityMigration(BzCleaner):
+    """Drop old severities to let teams retriage them.
+
+    TODO: This script is temporary; it should be removed once all old severities
+    are dropped.
+    """
+
+    no_bugmail = True
+
+    def __init__(self):
+        super().__init__()
+        self.team_bugs_count = {}
+        self.component_team = self._get_component_team_mapping()
+
+    def description(self):
+        return "Bugs with old severities"
+
+    def must_run(self, date):
+        return date.weekday() == 0  # Monday
+
+    def columns(self):
+        return ["team_name", "id", "summary"]
+
+    def _get_component_team_mapping(self):
+        result = {}
+
+        def handler(product, data):
+            for component in product["components"]:
+                data[ComponentName(product["name"], component["name"])] = component[
+                    "team_name"
+                ]
+
+        BugzillaProduct(
+            product_types="accessible",
+            include_fields=[
+                "name",
+                "components.name",
+                "components.team_name",
+            ],
+            product_handler=handler,
+            product_data=result,
+        ).wait()
+
+        return result
+
+    def handle_bug(self, bug, data):
+        component_name = ComponentName(bug["product"], bug["component"])
+        team_name = self.component_team[component_name]
+        bugs_count = self.team_bugs_count.get(team_name, 0)
+        if bugs_count >= 10:
+            return None
+
+        self.team_bugs_count[team_name] = bugs_count + 1
+
+        bugid = str(bug["id"])
+        data[bugid] = {
+            "id": bug["id"],
+            "summary": bug["summary"],
+            "team_name": team_name,
+        }
+
+        return bug
+
+    def get_autofix_change(self):
+        return {
+            "keywords": {"remove": "triaged"},
+            "severity": "--",
+            "comment": {
+                "body": "In the process of [migrating remaining bugs to the new severity system](https://bugzilla.mozilla.org/show_bug.cgi?id=1789259), the severity for this bug cannot be automatically determined. Please retriage this bug using the [new severity system](https://wiki.mozilla.org/BMO/UserGuide/BugFields#bug_severity).",
+            },
+        }
+
+    def get_bz_params(self, date):
+        params = {
+            "include_fields": ["product", "component"],
+            "resolution": "---",
+            "bug_severity": {"blocker", "critical", "major"},
+            "f1": "cf_crash_signature",
+            "o1": "isempty",
+        }
+
+        return params
+
+
+if __name__ == "__main__":
+    SeverityMigration().run()

--- a/runauto_nag_weekdays.sh
+++ b/runauto_nag_weekdays.sh
@@ -184,6 +184,9 @@ python -m auto_nag.scripts.inactive_reviewer --production
 # Nag on fuzz blocker bugs
 python -m auto_nag.scripts.fuzz_blockers --production
 
+# Drop old severities
+python -m auto_nag.scripts.severity_migration --production
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m auto_nag.log --send

--- a/templates/severity_migration.html
+++ b/templates/severity_migration.html
@@ -1,0 +1,24 @@
+<p>The following {{ plural('bug was', data, pword='bugs were') }} using the old severity system. The severity now is dropped to let teams retriage them:
+    <table {{ table_attrs }}>
+      <thead>
+        <tr>
+            <th>Team Name</th><th>Bug</th><th>Summary</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for i, (team_name, bugid, summary) in enumerate(data) -%}
+        <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+            <td>
+              {{ team_name | e }}
+            </td>
+          <td>
+            <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+           </td>
+          <td>
+            {{ summary | e }}
+          </td>
+        </tr>
+        {% endfor -%}
+      </tbody>
+    </table>
+</p>


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Resolves #1484 

## Dry-run

<details>
<summary>Click to expand the dry-run output!</summary><br>

<p>The following bugs were using the old severity system. The severity now is dropped to let teams retriage them:
<table style="border:1px solid black;border-collapse:collapse;" border="1">
<thead>
<tr>
<th>Team Name</th><th>Bug</th><th>Summary</th>
</tr>
</thead>
<tbody>
<tr bgcolor="#E0E0E0">
<td>
Accessibility
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1623221">1623221</a>
</td>
<td>
Large interactive SVG graph completely deadlocks Firefox
</td>
</tr>
<tr >
<td>
Accessibility
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1579148">1579148</a>
</td>
<td>
Default behavior of new profiles contain migraine triggers
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Accessibility
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1283746">1283746</a>
</td>
<td>
Assertion failure: consumed == aData.NewTree().Length(), at accessible/ipc/DocAccessibleParent.cpp:49 | runner.py | application crashed [@ libxul.so + 0x2dc46a7]
</td>
</tr>
<tr >
<td>
Accessibility
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=738146">738146</a>
</td>
<td>
[NOT Firefox: SeaMonkey only] &#34;treeupdate/test_imagemap.html | Test timed out.&#34;
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Accessibility
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=732872">732872</a>
</td>
<td>
Firefox runs extremely slowly when Windows Speech Recognition is running [meta]
</td>
</tr>
<tr >
<td>
Accessibility
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=718237">718237</a>
</td>
<td>
[SeaMonkey] &#34;accessible/events/test_focus_autocomplete.xul | Test timed out.&#34; (which also causes lots of &#34;gA11yEventListeners is undefined&#34; on following tests)
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Accessibility
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=718235">718235</a>
</td>
<td>
[SeaMonkey] &#34;a11y/accessible/events/test_focus_general.html | Doubled event { event type: focus, target:  &#39;link&#39;} in test with ID = &#39; &#39;link&#39;  &#39;tab shift &#39; key&#39;.&#34;
</td>
</tr>
<tr >
<td>
Accessibility
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=644103">644103</a>
</td>
<td>
[meta] smart events filtering depending on event consumer
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Accessibility
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=570995">570995</a>
</td>
<td>
Loading testcase from bug 522847 has terrible performance with NVDA running
</td>
</tr>
<tr >
<td>
Accessibility
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=395955">395955</a>
</td>
<td>
Superfluous text change events being fired
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
CI and Quality Tools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1229549">1229549</a>
</td>
<td>
a try run of a change that crashes on startup doesn&#39;t produce useful diagnostics
</td>
</tr>
<tr >
<td>
CI and Quality Tools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1228647">1228647</a>
</td>
<td>
[mozcrash] minidump files are not saved to MINIDUMP_SAVE_PATH if symbols cannot be downloaded
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
CI and Quality Tools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1200908">1200908</a>
</td>
<td>
Run mochitest-oth-e10s in automation
</td>
</tr>
<tr >
<td>
CI and Quality Tools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1196447">1196447</a>
</td>
<td>
Fix mozbase version conflicts in case of incompatible API changes
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
CI and Quality Tools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1082989">1082989</a>
</td>
<td>
qa_rebus:exception observed
</td>
</tr>
<tr >
<td>
CI and Quality Tools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1045205">1045205</a>
</td>
<td>
mochitest performance regression from structure logging on tests with large numbers of assertions
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
CI and Quality Tools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1000995">1000995</a>
</td>
<td>
Write Android Debug assertions to main test log
</td>
</tr>
<tr >
<td>
CI and Quality Tools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=755955">755955</a>
</td>
<td>
The reftest framework runs the test and the reference with random :hover state - causing random orange
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
CI and Quality Tools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=649776">649776</a>
</td>
<td>
enable color correction for reftests
</td>
</tr>
<tr >
<td>
CI and Quality Tools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=388169">388169</a>
</td>
<td>
Changing nsIPrintSettings.idl uuid causes printing reftest failures on win32 firefox unit test tinderboxes
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Credential Management
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1626247">1626247</a>
</td>
<td>
[macOS] The operating system&#8217;s authentication dialog accepts the empty password only at the second attempt
</td>
</tr>
<tr >
<td>
Credential Management
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1421634">1421634</a>
</td>
<td>
If a tab that has the autofill fields is detached to a new window the autofill doesn&#39;t work
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Credential Management
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=799598">799598</a>
</td>
<td>
&#39;No matching logins&#39; error when updating saved HTTP auth. password that was rejected by the server
</td>
</tr>
<tr >
<td>
Credential Management
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=653132">653132</a>
</td>
<td>
auto-filled password fields should not have their values available to javascript
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Credential Management
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=585591">585591</a>
</td>
<td>
Password manager detects an invisible input with display:none as the username field (affects vBulletin 4)
</td>
</tr>
<tr >
<td>
Credential Management
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=554566">554566</a>
</td>
<td>
remember password prompt displays credit card number(!) not user id for amtrak site when guest login is used
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Credential Management
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=520561">520561</a>
</td>
<td>
Autocomplete is too aggressive and overwrites values of hidden fields.
</td>
</tr>
<tr >
<td>
Credential Management
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=381681">381681</a>
</td>
<td>
Form autocomplete information can be seen by evil sites convincing users to press arrow keys
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Crypto
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=418644">418644</a>
</td>
<td>
ocspclnt deficient for problem analysis
</td>
</tr>
<tr >
<td>
Crypto
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=404639">404639</a>
</td>
<td>
core file detection must show stacks
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Crypto
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=397441">397441</a>
</td>
<td>
find the code that creates key3 DB files without global salts
</td>
</tr>
<tr >
<td>
Crypto
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=391775">391775</a>
</td>
<td>
PKIX leaks locks because reference counting no-ops in useArena configuration
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Crypto
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=391578">391578</a>
</td>
<td>
PK11_MakeCertFromHandle sets VALID_CA improperly
</td>
</tr>
<tr >
<td>
Crypto
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=391575">391575</a>
</td>
<td>
VALID_CA trust flags set improperly - tracking bug
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Crypto
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=372478">372478</a>
</td>
<td>
Latest security updates break SSL on W9x systems
</td>
</tr>
<tr >
<td>
Crypto
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=339921">339921</a>
</td>
<td>
Coverity 410, NULL ptr crash in certdb_SaveSingleProfile
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Crypto
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=330407">330407</a>
</td>
<td>
Document SSL_ConfigMPServerSIDCache can be called without NSS init
</td>
</tr>
<tr >
<td>
Crypto
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=327684">327684</a>
</td>
<td>
cmsutil: problem enveloping: security library: invalid algorithm.
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
DOM Core
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=379642">379642</a>
</td>
<td>
javascript onkeydown/onkeyup event not triggered for multiple non control keys simultaneously pressed on linux.
</td>
</tr>
<tr >
<td>
DOM Core
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=363840">363840</a>
</td>
<td>
IFrame on refresh of page, does not show the correct content.
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
DOM Core
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=356558">356558</a>
</td>
<td>
in additional to 354176 - Firefox displays cached iFrame instead of the new iFrame SRC that is defined.
</td>
</tr>
<tr >
<td>
DOM Core
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=347689">347689</a>
</td>
<td>
Improve plaintext serialization and editing of spaces
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
DOM Core
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=336911">336911</a>
</td>
<td>
openDialog //chrome without check existence
</td>
</tr>
<tr >
<td>
DOM Core
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=329264">329264</a>
</td>
<td>
Use of XMLHttpRequest object does not work inside onUnload JS event
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
DOM Core
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=326206">326206</a>
</td>
<td>
XML parser chokes on extremely long attributes
</td>
</tr>
<tr >
<td>
DOM Core
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=321460">321460</a>
</td>
<td>
css/xpat driver segmentation fault on startup
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
DOM Core
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=319223">319223</a>
</td>
<td>
mouseover and mouseout events are treated as untrusted
</td>
</tr>
<tr >
<td>
DOM Core
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=316809">316809</a>
</td>
<td>
Keydown event not fired on table
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
DOM LWS
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1609775">1609775</a>
</td>
<td>
AddressSanitizer: SEGV /builds/worker/workspace/build/src/ipc/glue/MessageLink.cpp:151:5 in mozilla::ipc::ProcessLink::SendMessage(IPC::Message*)
</td>
</tr>
<tr >
<td>
DOM LWS
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1578458">1578458</a>
</td>
<td>
MOZ_CRASH(&#34;Origin must be available when deserialized&#34;) on malicious IPC input [@mozilla::ipc::PrincipalInfoToPrincipal]
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
DOM LWS
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1469419">1469419</a>
</td>
<td>
Figure out and implement what should happen when there are two active calls to PaymentRequest.show
</td>
</tr>
<tr >
<td>
DOM LWS
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1456479">1456479</a>
</td>
<td>
Implement Request.isReloadNavigation
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
DOM LWS
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1441589">1441589</a>
</td>
<td>
Frequent dom/tests/mochitest/fetch/test_fetch_basic_sw_reroute.html | Worker: worker failed to import test_fetch_basic.js; when Gecko 60 merges to Beta on 2018-03-01
</td>
</tr>
<tr >
<td>
DOM LWS
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1433562">1433562</a>
</td>
<td>
Firefox build error
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
DOM LWS
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1229997">1229997</a>
</td>
<td>
&#34;Assertion failure: mIdleTimer&#34;
</td>
</tr>
<tr >
<td>
DOM LWS
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1221863">1221863</a>
</td>
<td>
&#34;Assertion failure: mCommonParams.metadata().name() == databaseName&#34; with null in database name
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
DOM LWS
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1183245">1183245</a>
</td>
<td>
Service worker registration should be wiped when origin storage is wiped
</td>
</tr>
<tr >
<td>
DOM LWS
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=399791">399791</a>
</td>
<td>
Spellcheck accesses computed style on nodes outside the document
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Desktop Integrations
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1589978">1589978</a>
</td>
<td>
Taking a screenshot in headless CLI hangs on Linux
</td>
</tr>
<tr >
<td>
Desktop Integrations
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1505436">1505436</a>
</td>
<td>
Uninstall fails when using MSI installer for the task
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Desktop Integrations
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1505089">1505089</a>
</td>
<td>
All kinds of weird message channel failures and final crash in mozStorageService.cpp:807 when using --headless and --silent arguments
</td>
</tr>
<tr >
<td>
Desktop Integrations
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1206828">1206828</a>
</td>
<td>
Update request failures
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Desktop Integrations
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1056056">1056056</a>
</td>
<td>
[Linux] Firefox can&#39;t be set as default browser
</td>
</tr>
<tr >
<td>
Desktop Integrations
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=656087">656087</a>
</td>
<td>
Windows jumplists don&#39;t work with different app-name
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Desktop Integrations
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=433730">433730</a>
</td>
<td>
ajust interface when OS is configured with big font (more than 16pt)
</td>
</tr>
<tr >
<td>
Desktop Integrations
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=315278">315278</a>
</td>
<td>
Update process produces a broken application when disk space is low
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Desktop Integrations
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=305797">305797</a>
</td>
<td>
Firefox installer / uninstaller screens ignore system font size
</td>
</tr>
<tr >
<td>
Desktop Integrations
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=266008">266008</a>
</td>
<td>
MacOSX &#34;Netscape document&#34; won&#39;t display properly after drag and drop
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
DevTools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1610531">1610531</a>
</td>
<td>
Sending the response with huge amount of data hangs Firefox
</td>
</tr>
<tr >
<td>
DevTools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1580700">1580700</a>
</td>
<td>
Hang in &#34;WebDriver:SwitchToFrame&#34; when a unexpected Javascript error is thrown
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
DevTools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1520302">1520302</a>
</td>
<td>
Decide how to handle window manipulation methods with xvfb and no window manager present
</td>
</tr>
<tr >
<td>
DevTools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1512027">1512027</a>
</td>
<td>
Disabling Content Blocking for a site hides the tracking icons in Netmonitor
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
DevTools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1506127">1506127</a>
</td>
<td>
Shutdown hang in serve.py::ServerProc.stop()  when stopping fixture server
</td>
</tr>
<tr >
<td>
DevTools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1491971">1491971</a>
</td>
<td>
Hangs in &#34;WebDriver:FullscreenWindow&#34;
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
DevTools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=580627">580627</a>
</td>
<td>
Source Code Line Numbers 54-57 are repeated twice
</td>
</tr>
<tr >
<td>
DevTools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=365642">365642</a>
</td>
<td>
View Selection Source consumes large amounts of memory and loops with high cpu
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
DevTools
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=166786">166786</a>
</td>
<td>
Can&#39;t save / view source POST query (e.g. ebay auction)
</td>
</tr>
<tr >
<td>
Frontend
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=349858">349858</a>
</td>
<td>
Multiple consecutive doubleclicks on Thunderbird icon open/start several windows (or processes) on Windows systems on same thunderbird profile
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Frontend
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=345067">345067</a>
</td>
<td>
Issues with prompt service&#39;s confirmEx - confirmEx always returns 1 when user closes dialog window using the X button in titlebar
</td>
</tr>
<tr >
<td>
Frontend
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=334835">334835</a>
</td>
<td>
Download Manager should not delete modified/moved files, or files it didn&#39;t create
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Frontend
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=328103">328103</a>
</td>
<td>
RDF tree listener after didRebuild  - takes upto 500ms to assign something tree.view
</td>
</tr>
<tr >
<td>
Frontend
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=327699">327699</a>
</td>
<td>
&#34;Funny&#34; behavior when Extension-Manager haven&#39;t enough system-rights to manage all files - Gecko needs an better system-error handling
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Frontend
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=327049">327049</a>
</td>
<td>
Unable to save attachments to folder or desktop from email messages or websites
</td>
</tr>
<tr >
<td>
Frontend
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=324781">324781</a>
</td>
<td>
Firefox should honor Content-Type instead of Content-Encoding or extension
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Frontend
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=324021">324021</a>
</td>
<td>
No name in downloading file
</td>
</tr>
<tr >
<td>
Frontend
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=314359">314359</a>
</td>
<td>
Dragging image to &#34;download&#34; toolbar button allows creating executable files
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Frontend
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=309953">309953</a>
</td>
<td>
toolbarbuttons aren&#39;t in sync with their commands after customizing
</td>
</tr>
<tr >
<td>
GFX
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=977249">977249</a>
</td>
<td>
Intel GMA 3150 driver incorrectly blocked
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
GFX
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=711171">711171</a>
</td>
<td>
mem lead when force enable acceleration
</td>
</tr>
<tr >
<td>
GFX
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=705555">705555</a>
</td>
<td>
Sites show so fuzzy they are nearly unreadable
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
GFX
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=691169">691169</a>
</td>
<td>
images currently being displayed by fennec should not be discarded
</td>
</tr>
<tr >
<td>
GFX
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=676068">676068</a>
</td>
<td>
Arabic fonts broken on LG phones
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
GFX
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=673639">673639</a>
</td>
<td>
Color management with specified ICC profile does not work.
</td>
</tr>
<tr >
<td>
GFX
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=647238">647238</a>
</td>
<td>
Jerky animation using HTML5 Canvas 2D with Firefox 4
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
GFX
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=327074">327074</a>
</td>
<td>
An 8BPP RLE encoded BMP with a row containing too many pixels fails to open/decompress
</td>
</tr>
<tr >
<td>
GFX
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=129546">129546</a>
</td>
<td>
Need to have views reparented with their widgets
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
GFX
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=91956">91956</a>
</td>
<td>
Eliminate nsFontCache
</td>
</tr>
<tr >
<td>
Javascript
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1219128">1219128</a>
</td>
<td>
Assertion failure: inited == hasPrototype(key), at vm/GlobalObject.h:334 with OOM
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Javascript
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1197958">1197958</a>
</td>
<td>
JSIL fails to load with &#39;Not allowed to define a non-configurable property on the WindowProxy object&#39;
</td>
</tr>
<tr >
<td>
Javascript
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1165569">1165569</a>
</td>
<td>
ES6 destructuring assignment performance too slow
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Javascript
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1112945">1112945</a>
</td>
<td>
enable-shared-js builds broken by GCCellPtr being used in XPCOM tests
</td>
</tr>
<tr >
<td>
Javascript
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1104159">1104159</a>
</td>
<td>
&#34;Highway at night&#34; javascript demo OOM crashes Firefox for Android
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Javascript
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1057530">1057530</a>
</td>
<td>
[meta] Reduce our GC max-pause
</td>
</tr>
<tr >
<td>
Javascript
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=736204">736204</a>
</td>
<td>
Testcase from bug 721006 and reloading causes Fennec to die
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Javascript
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=701026">701026</a>
</td>
<td>
Crash on Dromaeo DOM tests
</td>
</tr>
<tr >
<td>
Javascript
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=698132">698132</a>
</td>
<td>
Assertion failure: !vp-&gt;isMagic(), at mozilla/js/src/jsobj.cpp:6820
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Javascript
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=589748">589748</a>
</td>
<td>
Assertion failure: stackBase, at jsnativestack.cpp:205 on alpha
</td>
</tr>
<tr >
<td>
Layout
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=428335">428335</a>
</td>
<td>
max-content width calculation doesn&#39;t account for possibility that two floats in different blocks could be next to each other
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Layout
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=406653">406653</a>
</td>
<td>
We shouldn&#39;t create frames for non-SVG in SVG except in foreignObject
</td>
</tr>
<tr >
<td>
Layout
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=402442">402442</a>
</td>
<td>
Back/Forward button stops working when navigating to another page while printing
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Layout
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=401121">401121</a>
</td>
<td>
Print output truncated to 1 page, with table &gt; short div &gt; tall div
</td>
</tr>
<tr >
<td>
Layout
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=388529">388529</a>
</td>
<td>
ReParentStyleContext doesn&#39;t process resulting style changes
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Layout
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=339128">339128</a>
</td>
<td>
[meta] StirTable meta bug
</td>
</tr>
<tr >
<td>
Layout
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=335054">335054</a>
</td>
<td>
add assertions that we don&#39;t change the content tree during reflow, frame construction, or painting
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Layout
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=335053">335053</a>
</td>
<td>
add assertions that we don&#39;t execute script during frame construction, reflow or painting
</td>
</tr>
<tr >
<td>
Layout
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=330096">330096</a>
</td>
<td>
{inc}CSS conflict :: display: -moz-inline-box and display: table-cell
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Layout
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=315186">315186</a>
</td>
<td>
Dock and page flicker on mouseover (regression).
</td>
</tr>
<tr >
<td>
Low Level
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1605137">1605137</a>
</td>
<td>
NSPR Test join (19:14:24)[taskcluster:error] Aborting task...
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Low Level
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1483193">1483193</a>
</td>
<td>
Weather.com website cannot be loaded: &#34;The page isn&#39;t redirecting properly&#34; in EU countries
</td>
</tr>
<tr >
<td>
Low Level
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1392513">1392513</a>
</td>
<td>
Build bustage on NSPR after Bug 1310197
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Low Level
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1182378">1182378</a>
</td>
<td>
Building with ASan on Mac: Undefined symbol &#34;___lsan_ignore_object&#34;
</td>
</tr>
<tr >
<td>
Low Level
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1057551">1057551</a>
</td>
<td>
NULL deref in MOZ_RELEASE_ASSERT with ASAN detect_stack_use_after_return
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Low Level
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=671521">671521</a>
</td>
<td>
Problems building NSS 3.12.3 with NSPR 4.7.5 on AIX 7.1 in 64-bit mode.
</td>
</tr>
<tr >
<td>
Low Level
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=335303">335303</a>
</td>
<td>
Null pointer dereference in pt_PostNotifyToCvar (pr/src/pthreads/ptsynch.c)
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Low Level
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=282994">282994</a>
</td>
<td>
Crash in debug build if I press submit button. Problem is with PR_dtoa function on ARM without FP unit.
</td>
</tr>
<tr >
<td>
Low Level
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=130020">130020</a>
</td>
<td>
Prototypes for many PL_str*() functions return |char *|-pointers for data passed as |const char *|
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Media
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1620871">1620871</a>
</td>
<td>
Tab spinner spins indefinitely
</td>
</tr>
<tr >
<td>
Media
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1594185">1594185</a>
</td>
<td>
Firefox does not play sound on .ogv video although automatic playback for audio and video is set in security preferences
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Media
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1566405">1566405</a>
</td>
<td>
Widevine DRM causes Windows bluescreen on pageload
</td>
</tr>
<tr >
<td>
Media
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1553253">1553253</a>
</td>
<td>
AddressSanitizer: SEGV /builds/worker/workspace/build/src/dom/html/HTMLMediaElement.cpp:4699:7 in mozilla::dom::HTMLMediaElement::UpdateSrcMediaStreamPlaying(unsigned int)
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Media
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1519556">1519556</a>
</td>
<td>
Crash with incorrect simulcast layer specification
</td>
</tr>
<tr >
<td>
Media
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1509860">1509860</a>
</td>
<td>
Webm clusters ignored with mediasource API
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Media
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1496554">1496554</a>
</td>
<td>
MediaDecoder threads can contend on the allocator lock too much
</td>
</tr>
<tr >
<td>
Media
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1263809">1263809</a>
</td>
<td>
Gpu Temps/Coreclock/MemClock heavly Increase when I watch any youtube live stream normal videos are fine
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Media
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1253923">1253923</a>
</td>
<td>
media.hardware-video-decoding.force-enabled = true doesn&#39;t work
</td>
</tr>
<tr >
<td>
Media
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1073786">1073786</a>
</td>
<td>
[meta] Multiple channel support for Cubeb
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Mobile
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1492861">1492861</a>
</td>
<td>
Firefox will crash when trying to re-order an unloaded tab
</td>
</tr>
<tr >
<td>
Mobile
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1473536">1473536</a>
</td>
<td>
Crash in TabManager.selectTab(_:previous:)
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Mobile
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1455259">1455259</a>
</td>
<td>
Crash in CoreFoundation:  __CFRunLoopServiceMachPort + 196
</td>
</tr>
<tr >
<td>
Mobile
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1385259">1385259</a>
</td>
<td>
Tabs are not restored after a crash in some situations
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Mobile
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1358883">1358883</a>
</td>
<td>
Crash in WebKit: IPC::Connection::markCurrentlyDispatchedMessageAsInvalid()
</td>
</tr>
<tr >
<td>
Mobile
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1330045">1330045</a>
</td>
<td>
Full re-download of history results in a full re-upload
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Mobile
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1291831">1291831</a>
</td>
<td>
Devices from previous account appearing in Send Tab
</td>
</tr>
<tr >
<td>
Mobile
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1271576">1271576</a>
</td>
<td>
Crash in storage on initial sync after sign-in (with a particular account)
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Mobile
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1263704">1263704</a>
</td>
<td>
Unable to set a third party cookie
</td>
</tr>
<tr >
<td>
Mobile
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1250154">1250154</a>
</td>
<td>
Crash in UIKit: -[UIPopoverPresentationController presentationTransitionWillBegin] + 2884
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Mozilla
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1623340">1623340</a>
</td>
<td>
Microsoft Teams: video not supported in Firefox
</td>
</tr>
<tr >
<td>
Mozilla
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1561224">1561224</a>
</td>
<td>
EnvironmentError: Servers failed to start: &lt;random&gt;:8000, http:8000, &lt;random&gt;:8001, http:8001, &lt;random&gt;:8443, https:8443
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Mozilla
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1531004">1531004</a>
</td>
<td>
Skype for Web is not supported on Firefox
</td>
</tr>
<tr >
<td>
Mozilla
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1308028">1308028</a>
</td>
<td>
out of disk space not handled well (ambiguous error, no way to recover or retry)
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Mozilla
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1279228">1279228</a>
</td>
<td>
FF scrolls the page following the mouse instead of only when using the wheel or scroll bars
</td>
</tr>
<tr >
<td>
Mozilla
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1235978">1235978</a>
</td>
<td>
Tracking protection basic breaks redditp.com
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Mozilla
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1235020">1235020</a>
</td>
<td>
[gui] final result log output worthless
</td>
</tr>
<tr >
<td>
Mozilla
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1231950">1231950</a>
</td>
<td>
Ship (or use Desktop Fx) Android ADB with mozregression
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Mozilla
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1142189">1142189</a>
</td>
<td>
./mach web-platform-tests fails
</td>
</tr>
<tr >
<td>
Mozilla
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1084189">1084189</a>
</td>
<td>
Cannot use IME on Nightly builds which are launched by mozregression
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Networking
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=698523">698523</a>
</td>
<td>
nsHttpChannelAuthProvider::GetCredentialsForChallenge returns wrong credentials
</td>
</tr>
<tr >
<td>
Networking
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=685853">685853</a>
</td>
<td>
firefox file://... opens the wrong file when there&#39;s a firefox running on a different machine
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Networking
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=675446">675446</a>
</td>
<td>
Cached JS files can effectively be used as a per-URI cookie
</td>
</tr>
<tr >
<td>
Networking
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=660749">660749</a>
</td>
<td>
Firefox doesn&#39;t (re)validate certificates when loading a HTTPS page from the cache
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Networking
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=421128">421128</a>
</td>
<td>
Independent windows/tabs should not starve each other for network connections
</td>
</tr>
<tr >
<td>
Networking
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=407190">407190</a>
</td>
<td>
Network (HTTP) should timeout, if server does not react
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Networking
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=401846">401846</a>
</td>
<td>
Resume fails with &#34;Download could not be saved, because the source file could not be read&#34;
</td>
</tr>
<tr >
<td>
Networking
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=396384">396384</a>
</td>
<td>
Allocator mismatch for nsStandardURL::mHostA
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Networking
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=322385">322385</a>
</td>
<td>
WPAD: Auto-Detect Proxy not working until MIME type set
</td>
</tr>
<tr >
<td>
Networking
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=320965">320965</a>
</td>
<td>
Double-slash causes sending relative URI to proxy
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
OS Integration
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=740433">740433</a>
</td>
<td>
AV write [@ _VEC_memcpy / memmove | AtomImpl::AtomImpl(nsAString_internal const&amp;, unsigned int) ]
</td>
</tr>
<tr >
<td>
OS Integration
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=716762">716762</a>
</td>
<td>
startup cache needs a way of updating cached items
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
OS Integration
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=716560">716560</a>
</td>
<td>
[Win] Pop-up menus and address bar results disappearing when mouse is out on a secondary desktop display
</td>
</tr>
<tr >
<td>
OS Integration
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=716413">716413</a>
</td>
<td>
Frames below WSASend/WSARecv are not differentiated in Socorro, making it difficult to differentiate problems caused by various malware and buggy LSPs
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
OS Integration
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=700007">700007</a>
</td>
<td>
Crash in breakpad (google_breakpad::ReadTaskMemory ?)
</td>
</tr>
<tr >
<td>
OS Integration
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=685806">685806</a>
</td>
<td>
Panel anchored to the left edge of a toplevel xul window overlaps the window if moved to the left screen edge
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
OS Integration
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=382541">382541</a>
</td>
<td>
No way to stop Mozilla Crash Reporter from suppressing writing of Mac OS X crash log
</td>
</tr>
<tr >
<td>
OS Integration
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=326126">326126</a>
</td>
<td>
In fluxbox compose mail window shows up on wrong workspace
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
OS Integration
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=250906">250906</a>
</td>
<td>
null (%00) in filename fakes extension (ftp, file)
</td>
</tr>
<tr >
<td>
OS Integration
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=243206">243206</a>
</td>
<td>
nsTString::RFindCharInSet: Either docs or impl wrong
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Other
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1204210">1204210</a>
</td>
<td>
Intermittent fieldset-scroll-1.html | application crashed [@ libc.so + 0x188e8]
</td>
</tr>
<tr >
<td>
Other
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1115939">1115939</a>
</td>
<td>
Update to zlib git 3684659f485b63f7482a8dc600f51112c556ce9d to take some SIMD optimisations
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Other
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=702045">702045</a>
</td>
<td>
Tracking bug: make Firefox able to survive a Windows System Restore
</td>
</tr>
<tr >
<td>
Other
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=701674">701674</a>
</td>
<td>
cant add manifest from parent dir
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Other
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=573749">573749</a>
</td>
<td>
Small compressed file can become really big when uncompressed and run out of memory
</td>
</tr>
<tr >
<td>
Other
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=540530">540530</a>
</td>
<td>
If a page has the &#34;http-equiv=refresh and content=0&#34;, then Firefox goes 100% CPU and freezes
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Other
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=401301">401301</a>
</td>
<td>
[meta] firefox process still around after all windows closed
</td>
</tr>
<tr >
<td>
Other
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=332006">332006</a>
</td>
<td>
Avoid raw calls to snprintf
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Other
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=319143">319143</a>
</td>
<td>
large plain text file (150MB) uses all available memory and poor performance until hanging
</td>
</tr>
<tr >
<td>
Other
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=30942">30942</a>
</td>
<td>
Browser should remain responsive during most infinite loops
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Performance
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1605750">1605750</a>
</td>
<td>
AWSY tests should be listed as performance tests in try chooser
</td>
</tr>
<tr >
<td>
Performance
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1580582">1580582</a>
</td>
<td>
Leaving Twitter open degrades performance of entire browser and causes shutdown hang
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Performance
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1406382">1406382</a>
</td>
<td>
Unlimited RAM usage on some specific page
</td>
</tr>
<tr >
<td>
Performance
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1351755">1351755</a>
</td>
<td>
Provide &#34;Slight/Light/Low power/Battery saving/Battery saver&#34; mode option
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Performance
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=508427">508427</a>
</td>
<td>
High CPU on Linux even when in the background, possibly due to frequent polling
</td>
</tr>
<tr >
<td>
Pocket and User Journey
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1162698">1162698</a>
</td>
<td>
Thumbnail generation should have a time limit
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Privacy Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1572243">1572243</a>
</td>
<td>
Safebrowsing site warning bar disappears when tab is moved to new window, and stops showing future warnings
</td>
</tr>
<tr >
<td>
Privacy Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1563141">1563141</a>
</td>
<td>
Blocked malware/uncommon download options always open file, even if &#34;Save File&#34; was selected upon download
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Privacy Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1386565">1386565</a>
</td>
<td>
Disabling all Safe Browsing entries in about:config don&#39;t stop creating Safe Browsing files
</td>
</tr>
<tr >
<td>
Privacy Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1209803">1209803</a>
</td>
<td>
FIPS / Security Module / Master Password in Iceweasel + Icedove 38.x broken (when upgrading from 37.x)
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Privacy Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1122695">1122695</a>
</td>
<td>
Misleading messages in Control Center and &#34;More Information&#34; window when enforcing security.ssl.treat_unsafe_negotiation_as_broken
</td>
</tr>
<tr >
<td>
Privacy Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=986152">986152</a>
</td>
<td>
warn before opening any website on a raw IP address (make phishing scams less trivial)
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Privacy Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=625117">625117</a>
</td>
<td>
Can&#39;t include default domain in network.negotiate-auth.trusted-uris
</td>
</tr>
<tr >
<td>
Privacy Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=607575">607575</a>
</td>
<td>
Javascript code fills memory and virtual memory to 100%, slows down the computer, and potentially crashes the browser using document.title
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Privacy Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=579714">579714</a>
</td>
<td>
In ff a site silently opens an asx files and if MediaPlayer (default) opens it, a exploit in IE or other MS components allow code execution
</td>
</tr>
<tr >
<td>
RelEng
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1590547">1590547</a>
</td>
<td>
Possible provisioning failure on Android
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
RelEng
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1336606">1336606</a>
</td>
<td>
in try commit messages, using &#34;--tag &lt;tag&gt;&#34; results in &#34;android_emulator_unittest.py: error: no such option: --tag&#34; errors
</td>
</tr>
<tr >
<td>
Search and New Tab
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=750084">750084</a>
</td>
<td>
Tabs don&#39;t restore when FF window closed before restart [Mac]
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Search and New Tab
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=734643">734643</a>
</td>
<td>
Extremely slow deleting from history (seems some O(n^2) algorithm is there)
</td>
</tr>
<tr >
<td>
Search and New Tab
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=711465">711465</a>
</td>
<td>
Reconsider DOM session storage behavior
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Search and New Tab
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=707447">707447</a>
</td>
<td>
Dragging to the tabbar in RTL-mode indicator is broken
</td>
</tr>
<tr >
<td>
Search and New Tab
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=700467">700467</a>
</td>
<td>
Cannot open a new tab if using non existing proxy
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Search and New Tab
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=660566">660566</a>
</td>
<td>
Browser should ignore history Back/Forward action when triggered by command + arrow keys from a Design Mode area
</td>
</tr>
<tr >
<td>
Search and New Tab
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=655178">655178</a>
</td>
<td>
SECURITY:FormsAuthenticationCookie is not being cleaned up for apptabs upon closing browser.
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Search and New Tab
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=649151">649151</a>
</td>
<td>
User created functions in mozIStorageConnection will error if used asynchronously
</td>
</tr>
<tr >
<td>
Search and New Tab
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=423800">423800</a>
</td>
<td>
session restore performs GET when restoring tab that contained POST response
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Search and New Tab
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=381770">381770</a>
</td>
<td>
Should be able to undo changes in bookmarks from browser window (not only in Library)
</td>
</tr>
<tr >
<td>
Security Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1543674">1543674</a>
</td>
<td>
Implement WebAuthn cloud-based BLE extension
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Security Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1348279">1348279</a>
</td>
<td>
CryptoKeys cannot be read from IndexedDB: The object could not be cloned.
</td>
</tr>
<tr >
<td>
Security Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1337868">1337868</a>
</td>
<td>
Add Origin Attribute connection isolation tests for HTTP2, TLS, and WebSockets
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Security Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1280368">1280368</a>
</td>
<td>
Implement asynchronous content blocking API
</td>
</tr>
<tr >
<td>
Security Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=542230">542230</a>
</td>
<td>
Warning: Contains unauthenticated content triggered by content requested in onunload event handler of a non-encrypted page we&#39;re navigating from
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Security Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=441845">441845</a>
</td>
<td>
Security regression: cannot access through DOM external stylesheets
</td>
</tr>
<tr >
<td>
Security Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=435254">435254</a>
</td>
<td>
&#39;remember this selection&#39; not saved across FF sessions
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Security Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=433910">433910</a>
</td>
<td>
Secure site redirects to insecure site without a warning message
</td>
</tr>
<tr >
<td>
Security Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=312377">312377</a>
</td>
<td>
Page load fails silently when server sends invalid SSL record
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Security Engineering
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=233262">233262</a>
</td>
<td>
Mozilla is vulnerable to gzip bombs
</td>
</tr>
<tr >
<td>
Services
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1628416">1628416</a>
</td>
<td>
Failure initializing search engines after polling Production Preview (Remote Settings poll preview update)
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Services
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1595125">1595125</a>
</td>
<td>
Firefox deleted all keywords for searches
</td>
</tr>
<tr >
<td>
Services
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=801037">801037</a>
</td>
<td>
Firefox Sync empties all folders with same (default) name on the Source
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Services
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=800963">800963</a>
</td>
<td>
Sync fails to create HTTP Authentication header correctly for diacritics in the password
</td>
</tr>
<tr >
<td>
Services
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=692620">692620</a>
</td>
<td>
Some engines disabled during syncing with intermittent server failures
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Web Extensions
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1465811">1465811</a>
</td>
<td>
Unable to hide newly open tabs
</td>
</tr>
<tr >
<td>
Web Extensions
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1408443">1408443</a>
</td>
<td>
&#34;Available Updates&#34; section for removed add-ons
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Web Extensions
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1404662">1404662</a>
</td>
<td>
Sidebar has bug in rendering css borders
</td>
</tr>
<tr >
<td>
Web Extensions
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1386448">1386448</a>
</td>
<td>
Experiment and its extension won&#39;t be reload, unless/even restart the browser
</td>
</tr>
<tr bgcolor="#E0E0E0">
<td>
Web Extensions
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1190679">1190679</a>
</td>
<td>
[meta] Run WebExtensions out of process
</td>
</tr>
<tr >
<td>
Web Extensions
</td>
<td>
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=773514">773514</a>
</td>
<td>
AVG bypasses Firefox add-on user protections (was: Third-party install page is not shown after a second Firefox restart)
</td>
</tr>
</tbody>
</table>
</p>

</details>


## Statistics
The number of bugs per team (will be limited to 10 per week):
|Team Name | Number of bugs|
|--|:--:|
| Frontend | 250 |
| Security Engineering | 13 |
| Layout | 76 |
| Desktop Integrations | 12 |
| DOM Core | 123 |
| Other | 25 |
| Networking | 33 |
| OS Integration | 48 |
| GFX | 103 |
| Crypto | 58 |
| Low Level | 9 |
| DevTools | 9 |
| Credential Management | 8 |
| Search and New Tab | 58 |
| CI and Quality Tools | 42 |
| Accessibility | 16 |
| DOM LWS | 12 |
| Privacy Engineering | 9 |
| Javascript | 32 |
| Services | 5 |
| Mozilla | 15 |
| Mobile | 10 |
| Media | 22 |
| RelEng | 2 |
| Performance | 5 |
| Web Extensions | 6 |
| Pocket and User Journey | 1 |

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
