### PR TITLE
Revert "[severity_migration] Include Thunderbird-related products"

### DIFF
--- a/auto_nag/scripts/severity_migration.py
+++ b/auto_nag/scripts/severity_migration.py
@@ -97,11 +97,6 @@ class SeverityMigration(BzCleaner):
     def has_access_to_sec_bugs(self):
         return True
 
-    def get_products(self):
-        products = super().get_products()
-        products += ["Thunderbird", "Calendar", "Chat Core", "Mailnews Core"]
-        return products
-
     def get_bz_params(self, date):
         params = {
             "include_fields": ["product", "component"],


### PR DESCRIPTION


This reverts commit 10070e0e6595f247f467517fada3307a4a9254c5 (PR #648) based on Wayne's request on [Metrix](https://matrix.to/#/!xFamLORIeLrxDKGhLS:mozilla.org/$Obl4UxbQPOTSBbw00M_X63_DZP6jjLLqUloL0viqUBk?via=mozilla.org&via=matrix.org&via=totally.rip).

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
