### PR TITLE
[multifix_regression] Support merging keywords

### DIFF
--- a/auto_nag/scripts/multifix_regression.py
+++ b/auto_nag/scripts/multifix_regression.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from collections import defaultdict
+
 from auto_nag.multi_autofixers import (
     MultiAutoFixers,
     ToolsChanges,
@@ -23,6 +25,7 @@ class MultiFixRegressed(MultiAutoFixers):
             RegressionSetStatusFlags(),
             NeedinfoRegressionAuthor(),
             comment=self.__merge_comment,
+            keywords=self.__merge_keywords,
         )
 
     @staticmethod
@@ -38,6 +41,23 @@ class MultiFixRegressed(MultiAutoFixers):
             }
 
         raise UnexpectedToolsError(list(tools))
+
+    @staticmethod
+    def __merge_keywords(tools: ToolsChanges) -> dict:
+        merged_changes = defaultdict(set)
+        for changes in tools.values():
+            if "keywords" in changes:
+                for action, value in changes["keywords"].items():
+                    if isinstance(value, str):
+                        value = [value]
+
+                    merged_changes[action].update(value)
+
+        return {
+            "keywords": {
+                action: list(values) for action, values in merged_changes.items()
+            }
+        }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

This should fix the following error:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/rm_bot/relman-auto-nag/auto_nag/scripts/multifix_regression.py", line 44, in <module>
    MultiFixRegressed().run()
  File "/home/rm_bot/relman-auto-nag/auto_nag/multi_autofixers.py", line 108, in run
    new_changes = self._merge_changes_from_tools()
  File "/home/rm_bot/relman-auto-nag/auto_nag/multi_autofixers.py", line 134, in _merge_changes_from_tools
    raise MissingMergeFunctionError(field)
auto_nag.multi_autofixers.MissingMergeFunctionError: Error: missing merge function for 'keywords'
```

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
