### PR TITLE
[multifix_regression] Return the values only when merge keywords

### DIFF
--- a/auto_nag/scripts/multifix_regression.py
+++ b/auto_nag/scripts/multifix_regression.py
@@ -55,11 +55,7 @@ class MultiFixRegressed(MultiAutoFixers):
 
                 merged_changes[action].update(value)
 
-        return {
-            "keywords": {
-                action: list(values) for action, values in merged_changes.items()
-            }
-        }
+        return {action: list(values) for action, values in merged_changes.items()}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

This will fix the following error, where the `keywords` key should not be part of the merged value:
```
2022-10-05 20:32:29,065 - ERROR - regression_but_type_enhancement_task, regression_set_status_flags and needinfo_regression_author: Cannot put data for bug 1793513 (change => 
{
  "keywords": { "keywords": { "add": ["regression"] } },
  "comment": {
    "body": "Set release status flags based on info from the regressing bug 1749625\n\n:gw, since you are the author of the regressor, bug 1749625, could you take a look? Also, could you set the severity field?\n\nFor more information, please visit [auto_nag documentation](https://wiki.mozilla.org/Release_Management/autonag#needinfo_regression_author.py).\n"
  },
  "flags": [
    {
      "name": "needinfo",
      "requestee": "gwatson@mozilla.com",
      "status": "?",
      "new": "true"
    }
  ],
  "cf_status_firefox105": "affected",
  "cf_status_firefox106": "affected",
  "cf_status_firefox_esr102": "affected"
})
```

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
