### PR TITLE
Add the `blocker` severity to the severity constants

### DIFF
--- a/auto_nag/constants.py
+++ b/auto_nag/constants.py
@@ -6,11 +6,12 @@
 HIGH_PRIORITY = {"P1", "P2"}
 LOW_PRIORITY = {"P3", "P4", "P5"}
 
-HIGH_SEVERITY = {"S1", "critical", "S2", "major"}
+HIGH_SEVERITY = {"S1", "critical", "S2", "major", "blocker"}
 LOW_SEVERITY = {"S3", "normal", "S4", "minor", "trivial", "enhancement"}
 OLD_SEVERITY_MAP = {
     "critical": "S1",
     "major": "S2",
+    "blocker": "S2",
     "normal": "S3",
     "minor": "S4",
     "trivial": "S4",


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

The `blocker` severity has never been part of the severity constants, even before #1652.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
