### PR TITLE
[people] Check Bugzilla accounts for employees

### DIFF
--- a/auto_nag/iam.py
+++ b/auto_nag/iam.py
@@ -215,9 +215,17 @@ def update_bugzilla_emails(data: Dict[str, dict]) -> None:
         data: The data to update.
     """
 
+    # Currently employees can have permissions if they use their Mozilla email
+    # without the need to link their Bugzilla accounts to PMO. Thus we check here
+    # if employees already have a Bugzilla account using their Mozilla emails.
+    #
+    # Once BMO and PMO are fully integrated (plan in progress), this will be
+    # changed and employees will not have permissions unless they link their
+    # Bugzilla account to PMO.
     users_to_check = [
         person["bugzillaID"] or person["mail"] for person in data.values()
     ]
+
     users_by_bugzilla_id = {
         int(person["bugzillaID"]): person
         for person in data.values()


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
Fixes #1609, and at the same time unblocks #1529 and #1677 by adding the `found_on_bugzilla` field in the `people.json` file.

This PR will also solve cases where the Bugzilla account was changed or not linked, and the user currently uses their Mozilla email for their Bugzilla account.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [x] Type annotations added to new functions
- [x] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
