### PR TITLE
[people] Always search Bugzilla accounts using Mozilla emails

### DIFF
--- a/auto_nag/iam.py
+++ b/auto_nag/iam.py
@@ -243,7 +243,7 @@ def update_bugzilla_emails(data: Dict[str, dict]) -> None:
             and str(bz_user["id"]) != person["bugzillaID"]
         ):
             # If the linked Bugzilla account is still active, we should not
-            # overwrite use the other account.
+            # overwrite the other account.
             return
 
         if person["bugzillaEmail"] != bz_user["name"]:


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
This fixes #1529 and fixes #1677 for autonag. If the unlinked/new Bugzilla account is based on a Mozilla email, it will be automatically detected.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
