### PR TITLE
Exclude bugs from the Testing::mozregression component in the bisection_without_regressed_by tool

### DIFF
--- a/auto_nag/scripts/bisection_without_regressed_by.py
+++ b/auto_nag/scripts/bisection_without_regressed_by.py
@@ -3,7 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import re
-from typing import Dict
+from typing import Dict, List
 
 import requests
 from libmozdata import utils as lmdutils
@@ -54,7 +54,7 @@ class BisectionWithoutRegressedBy(BzCleaner):
         self,
         max_ni: int = 3,
         oldest_comment_weeks: int = 26,
-        components_skiplist: list[str] = ["Testing::mozregression"],
+        components_skiplist: List[str] = ["Testing::mozregression"],
     ) -> None:
         """Constructor
 


### PR DESCRIPTION
Fixes #1641

## Checklist

- [x] Type annotations added to new functions
- [x] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
