### PR TITLE
Set nightly status flag to `affected` on newly filed regression bugs

### DIFF
--- a/auto_nag/scripts/regression_new_set_nightly_affected.py
+++ b/auto_nag/scripts/regression_new_set_nightly_affected.py
@@ -1,0 +1,58 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from auto_nag import utils
+from auto_nag.bzcleaner import BzCleaner
+
+
+class RegressionNewSetNightlyAffected(BzCleaner):
+    """Set nightly status to affected on newly filed regressions"""
+
+    def __init__(self):
+        super().__init__()
+        if not self.init_versions():
+            return
+
+    def description(self):
+        return "Set nightly status to affected on newly filed regressions"
+
+    def get_bz_params(self, date):
+        return {
+            "resolution": ["---", "FIXED"],
+            "bug_status_type": "notequals",
+            "bug_status": "UNCONFIRMED",
+            "keywords": "regression",
+            "f1": "creation_ts",
+            "o1": "greaterthan",
+            "v1": "-7d",
+            "f2": "creation_ts",
+            "o2": "lessthan",
+            "v2": "-2d",
+            "f3": "regressed_by",
+            "o3": "isempty",
+            "f4": "cf_status_firefox_nightly",
+            "o4": "equals",
+            "v4": "---",
+            "f5": "cf_status_firefox_beta",
+            "o5": "equals",
+            "v5": "---",
+            "f6": "cf_status_firefox_release",
+            "o6": "equals",
+            "v6": "---",
+        }
+
+    def get_autofix_change(self):
+        nightly_status_flag = utils.get_flag(
+            self.versions["nightly"], "status", "nightly"
+        )
+        return {
+            "comment": {
+                "body": "This bug has been marked as a regression. Setting affected flag for nightly."
+            },
+            nightly_status_flag: "affected",
+        }
+
+
+if __name__ == "__main__":
+    RegressionNewSetNightlyAffected().run()

--- a/auto_nag/scripts/regression_new_set_nightly_affected.py
+++ b/auto_nag/scripts/regression_new_set_nightly_affected.py
@@ -48,7 +48,7 @@ class RegressionNewSetNightlyAffected(BzCleaner):
         )
         return {
             "comment": {
-                "body": "This bug has been marked as a regression. Setting affected flag for nightly."
+                "body": "This bug has been marked as a regression. Setting status flag for Nightly to `affected`."
             },
             nightly_status_flag: "affected",
         }

--- a/runauto_nag_weekdays.sh
+++ b/runauto_nag_weekdays.sh
@@ -196,6 +196,9 @@ python -m auto_nag.scripts.crash_small_volume --production
 # Detect outdated triage owner rotation definitions
 python -m auto_nag.scripts.triage_rotations_outdated --production
 
+# Set nightly status to affected on newly filed regressions
+python -m auto_nag.scripts.regression_new_set_nightly_affected --production
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m auto_nag.log --send

--- a/templates/regression_new_set_nightly_affected.html
+++ b/templates/regression_new_set_nightly_affected.html
@@ -1,0 +1,21 @@
+<p>The following {{ plural('bug has', data, pword='bugs have') }} the 'regression' keyword, thus the status flag for the nightly release is set to 'affected':
+    <table {{ table_attrs }}>
+      <thead>
+        <tr>
+          <th>Bug</th><th>Summary</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for i, (bugid, summary) in enumerate(data) -%}
+        <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+          <td>
+            <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+          </td>
+          <td>
+            {{ summary | e }}
+          </td>
+        </tr>
+        {% endfor -%}
+      </tbody>
+    </table>
+  </p>


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
Resolves #1506

Dry-run: [Bugzilla query](https://bugzilla.mozilla.org/buglist.cgi?resolution=---&resolution=FIXED&bug_status_type=notequals&bug_status=UNCONFIRMED&keywords=regression&f1=creation_ts&o1=greaterthan&v1=-7d&f2=creation_ts&o2=lessthan&v2=-2d&f3=regressed_by&o3=isempty&f4=cf_status_firefox_nightly&o4=equals&v4=---&f5=cf_status_firefox_beta&o5=equals&v5=---&f6=cf_status_firefox_release&o6=equals&v6=---&include_fields=id&include_fields=summary&include_fields=groups&f7=status_whiteboard&o7=notsubstring&v7=%5Bno-nag%5D&product=Core&product=Developer+Infrastructure&product=DevTools&product=External+Software+Affecting+Firefox&product=Fenix&product=Firefox&product=Firefox+for+iOS&product=Firefox+Build+System&product=GeckoView&product=JSS&product=NSPR&product=NSS&product=Remote+Protocol&product=Testing&product=Toolkit&product=Web+Compatibility&product=WebExtensions)



## Autonag wiki page
```wiki
{{AutonagRule
  | Rule name = Regression on nightly
  | Purpose   = Increase the visibility of regression bugs
  | Action    = Set nightly status flag to affected on newly filed regression bugs
  | Source    = regression_new_set_nightly_affected.py 
}}
```

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [x] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
