### PR TITLE
[close_intermittents] Increase the changes limit

### DIFF
--- a/auto_nag/scripts/close_intermittents.py
+++ b/auto_nag/scripts/close_intermittents.py
@@ -6,6 +6,8 @@ from auto_nag.bzcleaner import BzCleaner
 
 
 class Intermittents(BzCleaner):
+    normal_changes_max: int = 300
+
     def description(self):
         return "Intermittent test failure bugs unchanged in 21 days"
 


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

From the last run:
>  The tool close_intermittents has been aborted because it was attempting to apply changes on 214 bugs. The maximum number of changes allowed for this tool is 50.

The typical range for this tool in recent weeks is between 190 and 280. We run this tool once a week (on Tuesdays).

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
