### PR TITLE
Copy accessibility related metadata from duplicate bugs

### DIFF
--- a/auto_nag/scripts/duplicate_copy_metadata.py
+++ b/auto_nag/scripts/duplicate_copy_metadata.py
@@ -1,0 +1,172 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from typing import List
+
+from libmozdata.bugzilla import Bugzilla
+
+from auto_nag import utils
+from auto_nag.bzcleaner import BzCleaner
+
+
+class DuplicateCopyMetadata(BzCleaner):
+    def description(self):
+        return "Copied fields from duplicate bugs"
+
+    def handle_bug(self, bug, data):
+        bugid = str(bug["id"])
+        data[bugid] = bug
+
+        return bug
+
+    def get_bugs(self, date="today", bug_ids=[], chunk_size=None):
+        dup_bugs = super().get_bugs(date, bug_ids, chunk_size)
+
+        original_bug_ids = {bug["dupe_of"] for bug in dup_bugs.values()}
+        original_bugs = {}
+
+        Bugzilla(
+            {
+                "id": original_bug_ids,
+                "bug_status": "__open__",
+            },
+            include_fields=[
+                "id",
+                "summary",
+                "whiteboard",
+                "keywords",
+                "duplicates",
+            ],
+            bughandler=self.handle_bug,
+            bugdata=original_bugs,
+        ).wait()
+
+        results = {}
+        for bug_id, bug in original_bugs.items():
+            copied_fields = {}
+            for dup_bug_id in bug["duplicates"]:
+                dup_bug = dup_bugs.get(str(dup_bug_id))
+                if not dup_bug:
+                    continue
+
+                # Keywords: copy the `access` keyword from duplicates
+                if "access" not in bug["keywords"] and "access" in dup_bug["keywords"]:
+                    if "keywords" not in copied_fields:
+                        copied_fields["keywords"] = {
+                            "from": [dup_bug["id"]],
+                            "value": "access",
+                        }
+                    else:
+                        copied_fields["keywords"]["from"].append(dup_bug["id"])
+
+                # Whiteboard: copy the `access-s*` whiteboard rating from duplicates
+                if (
+                    "access-s" not in bug["whiteboard"]
+                    and "access-s" in dup_bug["whiteboard"]
+                ):
+                    new_access_tag = utils.get_whiteboard_access_rating(
+                        dup_bug["whiteboard"]
+                    )
+
+                    if (
+                        "whiteboard" not in copied_fields
+                        or new_access_tag < copied_fields["whiteboard"]["value"]
+                    ):
+                        copied_fields["whiteboard"] = {
+                            "from": [dup_bug["id"]],
+                            "value": new_access_tag,
+                        }
+                    elif new_access_tag == copied_fields["whiteboard"]["value"]:
+                        copied_fields["whiteboard"]["from"].append(dup_bug["id"])
+
+            if copied_fields:
+                copied_fields = sorted(
+                    (
+                        field,
+                        change["value"],
+                        utils.english_list(
+                            sorted(f"bug {bug_id}" for bug_id in change["from"])
+                        ),
+                    )
+                    for field, change in copied_fields.items()
+                )
+
+                results[bug_id] = {
+                    "id": bug_id,
+                    "summary": bug["summary"],
+                    "copied_fields": copied_fields,
+                }
+
+                self.set_autofix(bug, copied_fields)
+
+        return results
+
+    def set_autofix(self, bug: dict, copied_fields: List[tuple]) -> None:
+        """Set the autofix for a bug
+
+        Args:
+            bug: The bug to set the autofix for.
+            copied_fields: The list of copied fields with their values and the
+                bugs they were copied from (field, value, source).
+        """
+        bug_id = str(bug["id"])
+        autofix = {}
+
+        duplicates = {source for _, _, source in copied_fields}
+        comment = (
+            f"The following {utils.plural('field has', copied_fields, 'fields have')} been copied "
+            f"from {utils.plural('a duplicate bug', duplicates, 'duplicate bugs')}:\n"
+            "| Field | Value | Source |\n"
+            "| ----- | ----- | ------ |\n"
+        )
+
+        for field, value, source in copied_fields:
+            if field == "keywords":
+                autofix["keywords"] = {"add": value}
+            elif field == "whiteboard":
+                autofix["whiteboard"] = bug["whiteboard"] + value
+            else:
+                raise ValueError(f"Unsupported field: {field}")
+
+            comment += f"| {field.capitalize()} | {value} | {source} |\n"
+
+        comment += "\n\n" + self.get_documentation()
+        autofix["comment"] = {"body": comment}
+        self.autofix_changes[bug_id] = autofix
+
+    def columns(self):
+        return ["id", "summary", "copied_fields"]
+
+    def get_bz_params(self, date):
+        fields = [
+            "whiteboard",
+            "keywords",
+            "dupe_of",
+        ]
+
+        params = {
+            "include_fields": fields,
+            "resolution": "DUPLICATE",
+            "chfieldfrom": "-7d",
+            "chfield": [
+                "resolution",
+                "keywords",
+                "status_whiteboard",
+            ],
+            "j1": "OR",
+            "f1": "OP",
+            "f3": "status_whiteboard",
+            "o3": "anywordssubstr",
+            "v3": "[access-s",
+            "f4": "keywords",
+            "o4": "equals",
+            "v4": "access",
+            "f5": "CP",
+        }
+
+        return params
+
+
+if __name__ == "__main__":
+    DuplicateCopyMetadata().run()

--- a/auto_nag/utils.py
+++ b/auto_nag/utils.py
@@ -42,6 +42,7 @@ UTC_PAT = re.compile(r"UTC\+[^ \t]*")
 COL_PAT = re.compile(":[^:]*")
 BACKOUT_PAT = re.compile("^back(s|(ed))?[ \t]*out", re.I)
 BUG_PAT = re.compile(r"^bug[s]?[ \t]*([0-9]+)", re.I)
+WHITEBOARD_ACCESS_PAT = re.compile(r"\[access\-s\d\]")
 
 MAX_URL_LENGTH = 512
 
@@ -707,3 +708,19 @@ def is_weekend(date: Union[datetime.datetime, str]) -> bool:
     """Get if the provided date is a weekend day (Saturday or Sunday)"""
     parsed_date = lmdutils.get_date_ymd(date)
     return parsed_date.weekday() >= 5
+
+
+def get_whiteboard_access_rating(whiteboard: str) -> str:
+    """Get the access rating tag from the whiteboard.
+
+    Args:
+        whiteboard: a whiteboard string that contains an access rating tag.
+
+    Returns:
+        An access rating tag.
+    """
+
+    access_tags = WHITEBOARD_ACCESS_PAT.findall(whiteboard)
+    assert len(access_tags) == 1, "Should have only one access tag"
+
+    return access_tags[0]

--- a/runauto_nag_hourly.sh
+++ b/runauto_nag_hourly.sh
@@ -77,6 +77,9 @@ python -m auto_nag.scripts.prod_comp_changed_with_priority --production
 # Run regression related tools
 python -m auto_nag.scripts.multifix_regression --production
 
+# Copy metadata from duplicates
+python -m auto_nag.scripts.duplicate_copy_metadata --production
+
 # Send a mail if the logs are not empty
 # MUST ALWAYS BE THE LAST COMMAND
 python -m auto_nag.log --send

--- a/templates/duplicate_copy_metadata.html
+++ b/templates/duplicate_copy_metadata.html
@@ -1,0 +1,28 @@
+<p>The following {{ plural('bug has', data, pword='bugs have') }} fields that we copied from their duplicate bugs:
+  <table {{ table_attrs }}>
+    <thead>
+      <tr>
+        <th>Bug</th><th>Summary</th><th>Copied Fields</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for i, (bugid, summary, copied_fields) in enumerate(data) -%}
+      <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"{% endif -%}>
+        <td>
+          <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+        </td>
+        <td>
+          {{ summary | e }}
+        </td>
+        <td>
+          <ul>
+            {% for field, value, _ in copied_fields -%}
+            <li>{{ field.capitalize() }}: {{value}}</li>
+            {% endfor -%}
+          </ul>
+        </td>
+      </tr>
+      {% endfor -%}
+    </tbody>
+  </table>
+</p>


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
Resolves #1706 

The bot will be acting only on recently closed or changed bugs (touched within the previous hour).

# Autonag wiki page
```wiki
{{AutonagRule
  | Rule name = Copy metadata from duplicates
  | Purpose   = Increase the visibility of important information after closing a bug as a duplicate
  | Action    = Copy missed metadata from duplicate bugs
  | Source    = duplicate_copy_metadata.py 
}}
```

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [x] Type annotations added to new functions
- [x] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [x] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
