### PR TITLE
[regression_set_status_flags] Don't consider `---` for latest status

### DIFF
--- a/auto_nag/scripts/regression_set_status_flags.py
+++ b/auto_nag/scripts/regression_set_status_flags.py
@@ -85,7 +85,9 @@ class RegressionSetStatusFlags(BzCleaner):
         versions_status = sorted(
             (int(flag[len("cf_status_firefox") :]), status)
             for flag, status in bug.items()
-            if flag.startswith("cf_status_firefox") and "esr" not in flag
+            if status != "---"
+            and flag.startswith("cf_status_firefox")
+            and "esr" not in flag
         )
 
         if not versions_status:


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
Follow up to fix #1535

Example: https://bugzilla.mozilla.org/show_bug.cgi?id=1798014#c63 

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
