### PR TITLE
When the stalled keyword is present and the assignee is inactive, clear the assignee without needinfoing the triage owner

### DIFF
--- a/auto_nag/scripts/assignee_no_login.py
+++ b/auto_nag/scripts/assignee_no_login.py
@@ -103,7 +103,7 @@ class AssigneeNoLogin(BzCleaner):
         if (
             bug["priority"] not in HIGH_PRIORITY
             and bug["severity"] not in HIGH_SEVERITY
-        ):
+        ) or "stalled" in bug["keywords"]:
             needinfo = None
             autofix["comment"] = {
                 "body": "The bug assignee is inactive on Bugzilla, so the assignee is being reset."
@@ -149,6 +149,7 @@ class AssigneeNoLogin(BzCleaner):
             "flags",
             "priority",
             "severity",
+            "keywords",
         ]
         params = {
             "include_fields": fields,


### PR DESCRIPTION
Fixes #1758

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
