### PR TITLE
Use HIGH_PRIORITY and HIGH_SEVERITY constants from the constants module instead of redefining them

### DIFF
--- a/auto_nag/scripts/assignee_no_login.py
+++ b/auto_nag/scripts/assignee_no_login.py
@@ -8,10 +8,8 @@ from libmozdata import utils as lmdutils
 
 from auto_nag import people, utils
 from auto_nag.bzcleaner import BzCleaner
+from auto_nag.constants import HIGH_PRIORITY, HIGH_SEVERITY
 from auto_nag.user_activity import UserActivity
-
-HIGH_PRIORITY = {"P1", "P2"}
-HIGH_SEVERITY = {"S1", "critical", "S2", "major"}
 
 
 class AssigneeNoLogin(BzCleaner):


### PR DESCRIPTION
## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
