### PR TITLE
Don't consider P2 as high priority

### DIFF
--- a/auto_nag/constants.py
+++ b/auto_nag/constants.py
@@ -3,7 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-HIGH_PRIORITY = {"P1", "P2"}
+HIGH_PRIORITY = {"P1"}
 LOW_PRIORITY = {"P3", "P4", "P5"}
 
 HIGH_SEVERITY = {"S1", "critical", "S2", "major", "blocker"}

--- a/auto_nag/constants.py
+++ b/auto_nag/constants.py
@@ -4,6 +4,7 @@
 
 
 HIGH_PRIORITY = {"P1"}
+MEDIUM_PRIORITY = {"P2"}
 LOW_PRIORITY = {"P3", "P4", "P5"}
 
 HIGH_SEVERITY = {"S1", "critical", "S2", "major", "blocker"}


### PR DESCRIPTION
Given that priority is used inconsistently across teams, I think the only think we can rely upon is that P1 is high priority. So I propose to remove P2 from the high priority list.

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
