### PR TITLE
Remove seed-isort-config as it's no longer needed since isort 5

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,4 @@
 [settings]
-known_third_party = Levenshtein,alembic,dateutil,filelock,humanize,icalendar,icalevents,jinja2,libmozdata,numpy,pytz,requests,responses,sqlalchemy,tenacity,whatthepatch
 line_length = 88
 multi_line_output=3
 include_trailing_comma=True

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,4 @@
 repos:
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-      - id: seed-isort-config
   - repo: https://github.com/timothycrosley/isort
     rev: 5.10.1
     hooks:


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
Same as https://github.com/mozilla/bugbug/pull/3189

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
