### PR TITLE
Bump python-dateutil from 2.5.2 to 2.8.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ libmozdata==0.1.83
 numpy==1.21.5
 pep8==1.7.1
 pyflakes==3.0.1
-python-dateutil>=2.5.2
+python-dateutil>=2.8.2
 python-Levenshtein>=0.12.0
 pytz>=2018.9
 PyYAML==6.0


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Fixes #1845

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
