### PR TITLE
Be more restrictive when re-adding topcrash keywords

### DIFF
--- a/auto_nag/constants.py
+++ b/auto_nag/constants.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+BOT_MAIN_ACCOUNT = "release-mgmt-account-bot@mozilla.tld"
 
 HIGH_PRIORITY = {"P1"}
 MEDIUM_PRIORITY = {"P2"}

--- a/auto_nag/scripts/topcrash_add_keyword.py
+++ b/auto_nag/scripts/topcrash_add_keyword.py
@@ -5,6 +5,7 @@
 import itertools
 import re
 from collections import defaultdict
+from typing import Dict, Iterable
 
 from libmozdata.bugzilla import Bugzilla
 from libmozdata.connection import Connection
@@ -12,12 +13,17 @@ from libmozdata.connection import Connection
 from auto_nag import utils
 from auto_nag.bzcleaner import BzCleaner
 from auto_nag.constants import HIGH_SEVERITY
-from auto_nag.topcrash import Topcrash
+from auto_nag.topcrash import TOP_CRASH_IDENTIFICATION_CRITERIA, Topcrash
 
 MAX_SIGNATURES_PER_QUERY = 30
 
 
 class TopcrashAddKeyword(BzCleaner):
+    def __init__(self):
+        super().__init__()
+        self.topcrashes = None
+        self.topcrashes_restrictive = None
+
     def description(self):
         return "Bugs with missing topcrash keywords"
 
@@ -62,12 +68,20 @@ class TopcrashAddKeyword(BzCleaner):
         if not keywords_to_add:
             return
 
+        is_keywords_removed = utils.is_keywords_removed_by_autonag(bug, keywords_to_add)
+        if is_keywords_removed and not self._is_matching_restrictive_criteria(
+            top_crash_signatures
+        ):
+            return
+
         autofix = {
             "keywords": {
                 "add": list(keywords_to_add),
             },
             "comment": {
-                "body": self.get_matching_criteria_comment(top_crash_signatures),
+                "body": self.get_matching_criteria_comment(
+                    top_crash_signatures, is_keywords_removed
+                ),
             },
         }
 
@@ -76,6 +90,7 @@ class TopcrashAddKeyword(BzCleaner):
             ni_person
             and bug["severity"] not in HIGH_SEVERITY
             and "meta" not in bug["keywords"]
+            and not is_keywords_removed
         ):
             autofix["flags"] = [
                 {
@@ -100,8 +115,21 @@ class TopcrashAddKeyword(BzCleaner):
 
         return bug
 
-    def get_matching_criteria_comment(self, signatures):
-        matching_criteria = defaultdict(bool)
+    def get_matching_criteria_comment(
+        self,
+        signatures: list,
+        is_keywords_removed: bool,
+    ) -> str:
+        """Generate a comment with the matching criteria for the given signatures.
+
+        Args:
+            signatures: The list of signatures to generate the comment for.
+            is_keywords_removed: Whether the topcrash keywords was removed earlier.
+
+        Returns:
+            The comment for the matching criteria.
+        """
+        matching_criteria: Dict[str, bool] = defaultdict(bool)
         for signature in signatures:
             for criterion in self.topcrashes[signature]:
                 matching_criteria[criterion["criterion_name"]] |= criterion[
@@ -109,7 +137,12 @@ class TopcrashAddKeyword(BzCleaner):
                 ]
 
         introduction = (
-            "The bug is linked to ",
+            (
+                "Sorry for removing earlier but there is a recent "
+                "change in the ranking, so the bug is again linked to "
+                if is_keywords_removed
+                else "The bug is linked to "
+            ),
             (
                 "a topcrash signature, which matches "
                 if len(signatures) == 1
@@ -148,6 +181,30 @@ class TopcrashAddKeyword(BzCleaner):
 
         return bugs
 
+    def _is_matching_restrictive_criteria(self, signatures: Iterable) -> bool:
+        topcrashes = self._get_restrictive_topcrash_signatures()
+        return any(signature in topcrashes for signature in signatures)
+
+    def _get_restrictive_topcrash_signatures(self) -> dict:
+        if self.topcrashes_restrictive is None:
+            restrictive_criteria = []
+            for criterion in TOP_CRASH_IDENTIFICATION_CRITERIA:
+                restrictive_criterion = {
+                    **criterion,
+                    "tc_limit": criterion["tc_limit"] // 2,
+                }
+
+                if "tc_limit_startup" in criterion:
+                    restrictive_criterion["tc_limit_startup"] //= 2
+
+                restrictive_criteria.append(restrictive_criterion)
+
+            self.topcrashes_restrictive = Topcrash(
+                criteria=restrictive_criteria
+            ).get_signatures()
+
+        return self.topcrashes_restrictive
+
     def get_bz_params_list(self, date):
         self.topcrashes = Topcrash(date).get_signatures()
 
@@ -157,6 +214,7 @@ class TopcrashAddKeyword(BzCleaner):
             "severity",
             "keywords",
             "cf_crash_signature",
+            "history",
         ]
         params_base = {
             "include_fields": fields,

--- a/auto_nag/scripts/topcrash_add_keyword.py
+++ b/auto_nag/scripts/topcrash_add_keyword.py
@@ -138,7 +138,7 @@ class TopcrashAddKeyword(BzCleaner):
 
         introduction = (
             (
-                "Sorry for removing earlier but there is a recent "
+                "Sorry for removing the keyword earlier but there is a recent "
                 "change in the ranking, so the bug is again linked to "
                 if is_keywords_removed
                 else "The bug is linked to "

--- a/auto_nag/scripts/topcrash_bad_severity.py
+++ b/auto_nag/scripts/topcrash_bad_severity.py
@@ -33,6 +33,10 @@ class TopcrashBadSeverity(BzCleaner):
         self.extra_ni[bugid] = {
             "severity": bug["severity"],
         }
+
+        if utils.is_keywords_removed_by_autonag(bug, ["topcrash", "topcrash-startup"]):
+            return None
+
         return bug
 
     def get_extra_for_needinfo_template(self):

--- a/auto_nag/utils.py
+++ b/auto_nag/utils.py
@@ -8,7 +8,7 @@ import json
 import os
 import random
 import re
-from typing import Union
+from typing import Iterable, Union
 from urllib.parse import urlencode
 
 import dateutil.parser
@@ -24,6 +24,7 @@ from libmozdata.hgmozilla import Mercurial
 from requests.exceptions import HTTPError
 
 from auto_nag.constants import HIGH_PRIORITY, HIGH_SEVERITY, OLD_SEVERITY_MAP
+from auto_nag.history import History
 
 _CONFIG = None
 _CYCLE_SPAN = None
@@ -747,3 +748,23 @@ def create_bug(bug_data: dict) -> dict:
     )
     resp.raise_for_status()
     return resp.json()
+
+
+def is_keywords_removed_by_autonag(bug: dict, keywords: Iterable) -> bool:
+    """Check if the bug had any of the provided keywords removed by autonag.
+
+    Args:
+        bug: The bug to check.
+        keywords: The keywords to check.
+
+    Returns:
+        True if any of the keywords was removed by autonag, False otherwise.
+    """
+    return any(
+        keyword in change["removed"]
+        for entry in bug["history"]
+        if entry["who"] == History.BOT
+        for change in entry["changes"]
+        if change["field_name"] == "keywords"
+        for keyword in keywords
+    )

--- a/auto_nag/utils.py
+++ b/auto_nag/utils.py
@@ -23,8 +23,12 @@ from libmozdata.bugzilla import Bugzilla, BugzillaShorten
 from libmozdata.hgmozilla import Mercurial
 from requests.exceptions import HTTPError
 
-from auto_nag.constants import HIGH_PRIORITY, HIGH_SEVERITY, OLD_SEVERITY_MAP
-from auto_nag.history import History
+from auto_nag.constants import (
+    BOT_MAIN_ACCOUNT,
+    HIGH_PRIORITY,
+    HIGH_SEVERITY,
+    OLD_SEVERITY_MAP,
+)
 
 _CONFIG = None
 _CYCLE_SPAN = None
@@ -763,7 +767,7 @@ def is_keywords_removed_by_autonag(bug: dict, keywords: Iterable) -> bool:
     return any(
         keyword in change["removed"]
         for entry in bug["history"]
-        if entry["who"] == History.BOT
+        if entry["who"] == BOT_MAIN_ACCOUNT
         for change in entry["changes"]
         if change["field_name"] == "keywords"
         for keyword in keywords


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Resolves #1811

If the `topcrash` keyword was removed earlier by autonag:
- Do not needinfo to increase the severity (suggested by @amccreight).
- Apply more restrictive criteria (e.g., top 10 crashes will be top 5 crashes)
- Adjust the wording

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [x] Type annotations added to new functions
- [x] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
