### PR TITLE
bzcleaner: fix default preamble

### DIFF
--- a/auto_nag/bzcleaner.py
+++ b/auto_nag/bzcleaner.py
@@ -686,7 +686,7 @@ class BzCleaner(object):
 
         return self.organize(bugs)
 
-    def get_email(self, date: str, data: dict, preamble: str = None):
+    def get_email(self, date: str, data: dict, preamble: str = ""):
         """Get title and body for the email"""
         assert data, "No data to send"
 


### PR DESCRIPTION
Currently if preamble is not passed to get_email, we'll write the string "None" in the email body, instead of leaving it empty.

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
