### PR TITLE
Generate the release cycle span based on the Firefox Trains API instead of the wiki page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ humanize>=0.5.1
 icalendar==4.1.0
 icalevents==0.1.24
 Jinja2==3.1.2
-libmozdata==0.1.83
+libmozdata==0.1.85
 numpy==1.21.5
 pep8==1.7.1
 pyflakes==3.0.1


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Fixes #1903

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [x] Type annotations added to new functions
- [x] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
