### PR TITLE
Generate the soft freeze date  based on the Firefox Trains API instead of the wiki page

### DIFF
--- a/auto_nag/scripts/tracked_attention.py
+++ b/auto_nag/scripts/tracked_attention.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import humanize
 from libmozdata import utils as lmdutils
-from libmozdata.release_calendar import get_calendar
+from libmozdata.fx_trains import FirefoxTrains
 
 from auto_nag import utils
 from auto_nag.bzcleaner import BzCleaner
@@ -41,7 +41,8 @@ class TrackedAttention(BzCleaner):
 
         self.team_managers = TeamManagers()
 
-        soft_freeze_date = get_calendar()[0]["soft freeze"]
+        schedule = FirefoxTrains().get_release_schedule("nightly")
+        soft_freeze_date = lmdutils.get_date_ymd(schedule["soft_code_freeze"])
         today = lmdutils.get_date_ymd("today")
         soft_freeze_delta = soft_freeze_date - today
         assert soft_freeze_delta.days >= 0


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Fixes #1899

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
