### PR TITLE
[round_robin_calendar] Ignore emails from the JSON calendar

### DIFF
--- a/auto_nag/round_robin_calendar.py
+++ b/auto_nag/round_robin_calendar.py
@@ -150,13 +150,13 @@ class JSONCalendar(Calendar):
             return []
 
         if date == self.dates[i]:
-            person = self.team[i]
+            person = self.team[i][0]
         else:
-            person = self.team[i - 1] if i != 0 else self.team[0]
+            person = self.team[i - 1][0] if i != 0 else self.team[0][0]
 
-        self.cache[date] = [person]
+        self.cache[date] = res = [(person, self.people.get_bzmail_from_name(person))]
 
-        return [person]
+        return res
 
     def guess_cycle(self):
         diffs = [(x - y).days for x, y in zip(self.dates[1:], self.dates[:-1])]


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Fixes #1922 

With this, we will get the Bugzilla email from the `people.json` file instead of the JSON calendar. As a result, we will have the following benefits:

- We will not have an error if the calendar lists Mozilla email instead of Bugzilla email
- Only employees can be set as triage owners (more secure)

@marco-c are you aware of any case where limiting the triagers to employees could be a problem? We already have this behaviour for ICS calendars.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
