### PR TITLE
[close_intermittents] Autoclose intermittents that are P3 too

### DIFF
--- a/auto_nag/scripts/close_intermittents.py
+++ b/auto_nag/scripts/close_intermittents.py
@@ -45,7 +45,7 @@ class Intermittents(BzCleaner):
             "f11": "keywords",
             "o11": "nowords",
             "v11": "leave-open, test-verify-fail",
-            "priority": "P5",
+            "priority": ["P3", "P5"],
             "resolution": "---",
             "status_whiteboard_type": "notregexp",
             "status_whiteboard": "(leave open|leave-open|leaveopen|test disabled|test-disabled|testdisabled)",


### PR DESCRIPTION
Fixes #1996

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
