### PR TITLE
[patch_closed_bug] Disable the tool temporarily

### DIFF
--- a/runauto_nag_weekdays.sh
+++ b/runauto_nag_weekdays.sh
@@ -159,7 +159,8 @@ python -m auto_nag.scripts.inactive_ni_pending --production
 python -m auto_nag.scripts.crash_signature_confirm --production
 
 # Bugs with patches after being closed
-python -m auto_nag.scripts.patch_closed_bug --production
+# Disabled temporarily until fixing https://github.com/mozilla/relman-auto-nag/issues/1953
+# python -m auto_nag.scripts.patch_closed_bug --production
 
 # Confirm bugs with affected flags
 python -m auto_nag.scripts.affected_flag_confirm --production


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

Disabling the `patch_closed_bug` tool temporarily to avoid adding more noize. We should enable the tool back once https://github.com/mozilla/relman-auto-nag/issues/1953 is fixed.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/relman-auto-nag/labels/to-be-announced) tag added if this is worth announcing
