### PR TITLE
Update severity_inconsistency.py to NI the triage owner instead of an assignee when an accessibility severity is higher than the severity

### DIFF
--- a/bugbot/rules/severity_inconsistency.py
+++ b/bugbot/rules/severity_inconsistency.py
@@ -30,7 +30,7 @@ class SeverityInconsistency(BzCleaner):
         return ["id", "summary", "severity", "accessibility_severity"]
 
     def get_mail_to_auto_ni(self, bug):
-        for field in ["assigned_to", "triage_owner"]:
+        for field in ["triage_owner", "assigned_to"]:
             person = bug.get(field, "")
             if person and not utils.is_no_assignee(person):
                 return {"mail": person, "nickname": bug[f"{field}_detail"]["nick"]}


### PR DESCRIPTION
The Bugbot sends an NI to an assignee alone, instead of the triage owner, when the accessibility severity is higher than the severity:
> <release-mgmt-account-bot@mozilla.tld> ---
> The severity field for this bug is set to S3. However, the accessibility severity is higher, . :ayeddi, could you consider increasing the severity?

Another approach could be to remove the "assigned_to" field at all since all the bugs have always "triage_owner" filled in.

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
