### PR TITLE
Updated not_landed to get user nicks in 1 call and removed the duplicate - Closes #1101

### DIFF
--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -326,26 +326,22 @@ class NotLanded(BzCleaner):
             res[bugid] = d = bugs[bugid]
             self.extra_ni[bugid] = data["count"]
             assignee = d["assigned_to"]
-            nickname = d["nickname"]
 
             if not assignee:
-                assignee_id = bug_assignee_map[bugid]
-                assignee, nickname = bz_reviewers[assignee_id]
+                user_details = bz_reviewers[assignee]
+                assignee = user_details["id"]
+                nickname = user_details["nick"]
 
             if not assignee:
                 continue
 
             self.add_auto_ni(bugid, {"mail": assignee, "nickname": nickname})
 
-            common = all_reviewers & data["reviewers_phid"]
+            common = all_reviewers["name"] & data["reviewers_phid"]
             if common:
                 reviewer = random.choice(list(common))
                 self.add_auto_ni(
-                    bugid,
-                    {
-                        "mail": bz_reviewers[reviewer][0],
-                        "nickname": bz_reviewers[reviewer][1],
-                    },
+                    bugid, {"mail": bz_reviewers[reviewer], "nickname": None}
                 )
 
         return res

--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -252,7 +252,7 @@ class NotLanded(BzCleaner):
 
         return data
 
-    def get_bz_userid(self, phids):
+    def get_bz_users(self, phids):
         if not phids:
             return {}
 
@@ -263,7 +263,7 @@ class NotLanded(BzCleaner):
             return {}
 
         def handler(user, data):
-            data[str(user["id"])] = (user["name"], user["nick"])
+            data[str(user["id"])] = user
 
         data = {}
         BugzillaUser(
@@ -311,15 +311,15 @@ class NotLanded(BzCleaner):
         res = {}
 
         reviewers_phid = set()
-        nicknames = {}
+        bug_assignee_map = {}
         for bugid, data in bugs_patch.items():
             reviewers_phid |= data["reviewers_phid"]
             assignee = bugs[bugid]["assigned_to"]
             if not assignee:
                 assignee = max(data["author"], key=data["author"].get)
-                nicknames[bugid] = assignee
+                bug_assignee_map[bugid] = assignee
 
-        bz_reviewers = self.get_bz_userid(reviewers_phid)
+        bz_reviewers = self.get_bz_users(reviewers_phid)
         all_reviewers = set(bz_reviewers.keys())
 
         for bugid, data in bugs_patch.items():
@@ -329,7 +329,8 @@ class NotLanded(BzCleaner):
             nickname = d["nickname"]
 
             if not assignee:
-                assignee, nickname = bz_reviewers[nicknames[bugid]]
+                assignee_id = bug_assignee_map[bugid]
+                assignee, nickname = bz_reviewers[assignee_id]
 
             if not assignee:
                 continue


### PR DESCRIPTION
<!---
fixing duplicate call to get user nicks, addresses: #1101
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
