### PR TITLE
New rule to detect inactive patch authors

### DIFF
--- a/bugbot/rules/inactive_patch_author.py
+++ b/bugbot/rules/inactive_patch_author.py
@@ -20,8 +20,6 @@ PHAB_FILE_NAME_PAT = re.compile(r"phabricator-D([0-9]+)-url\.txt")
 
 
 class InactivePatchAuthors(BzCleaner, Nag):
-    """Bugs with patches authored by inactive patch authors"""
-
     def __init__(self):
         super().__init__()
         self.phab = PhabricatorAPI(utils.get_login_info()["phab_api_key"])

--- a/bugbot/rules/inactive_patch_author.py
+++ b/bugbot/rules/inactive_patch_author.py
@@ -23,9 +23,9 @@ class InactivePatchAuthors(BzCleaner, Nag):
     """Bugs with patches authored by inactive patch authors"""
 
     def __init__(self):
-        super(InactivePatchAuthors, self).__init__()
+        super().__init__()
         self.phab = PhabricatorAPI(utils.get_login_info()["phab_api_key"])
-        self.user_activity = UserActivity(include_fields=["nick"], phab=self.phab)
+        self.user_activity = UserActivity(phab=self.phab)
         self.default_assignees = utils.get_default_assignees()
         self.people = people.People.get_instance()
         self.no_bugmail = True

--- a/bugbot/rules/inactive_patch_author.py
+++ b/bugbot/rules/inactive_patch_author.py
@@ -7,7 +7,7 @@ import re
 from typing import Dict, List
 
 from libmozdata.connection import Connection
-from libmozdata.phabricator import PhabricatorAPI
+from libmozdata.phabricator import ConduitError, PhabricatorAPI
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 from bugbot import people, utils
@@ -96,7 +96,7 @@ class InactivePatchAuthors(BzCleaner, Nag):
                 else:
                     logging.info(f"Patch {rev_id} for bug {bugid} is already closed.")
 
-            except Exception as e:
+            except ConduitError as e:
                 logging.error(f"Failed to abandon patch {rev_id} for bug {bugid}: {e}")
 
         self.autofix_changes[bugid] = autofix

--- a/bugbot/rules/inactive_patch_author.py
+++ b/bugbot/rules/inactive_patch_author.py
@@ -112,8 +112,8 @@ class InactivePatchAuthors(BzCleaner, Nag):
                 for revision in self._fetch_revisions(_rev_ids):
                     author_phid = revision["fields"]["authorPHID"]
                     created_at = revision["fields"]["dateCreated"]
-                    if author_phid == "PHID-USER-eltrc7x5oplwzfguutrb":
-                        continue
+                    # if author_phid == "PHID-USER-eltrc7x5oplwzfguutrb":
+                    #     continue
                     revisions.append(
                         {
                             "rev_id": revision["id"],
@@ -131,13 +131,9 @@ class InactivePatchAuthors(BzCleaner, Nag):
         for revision in revisions:
             user_phids.add(revision["author_phid"])
 
-        try:
-            users = self.user_activity.get_phab_users_with_status(
-                list(user_phids), keep_active=False
-            )
-        except Exception as e:
-            logging.error(f"Error fetching Phabricator users with status: {e}")
-            users = {}
+        users = self.user_activity.get_phab_users_with_status(
+            list(user_phids), keep_active=False
+        )
 
         result: Dict[int, dict] = {}
         for revision in revisions:

--- a/bugbot/rules/inactive_patch_author.py
+++ b/bugbot/rules/inactive_patch_author.py
@@ -37,7 +37,6 @@ class InactivePatchAuthors(BzCleaner):
     def get_bugs(self, date="today", bug_ids=[], chunk_size=None):
         bugs = super().get_bugs(date, bug_ids, chunk_size)
 
-        logging.info(f"BUGS RETRIEVED > {bugs}")
         rev_ids = {rev_id for bug in bugs.values() for rev_id in bug["rev_ids"]}
         inactive_authors = self._get_inactive_patch_authors(list(rev_ids))
 
@@ -58,10 +57,9 @@ class InactivePatchAuthors(BzCleaner):
         return bugs
 
     def unassign_inactive_author(self, bugid, bug, inactive_patches):
-        # print(f"\n BUG >> {bugid} >> {bug}\n")
-        # prod = bug["product"]
-        # comp = bug["component"]
-        default_assignee = "bmah@mozilla.com"
+        prod = bug["product"]
+        comp = bug["component"]
+        default_assignee = self.default_assignees[prod][comp]
         autofix = {"assigned_to": default_assignee}
 
         comment = (
@@ -139,6 +137,8 @@ class InactivePatchAuthors(BzCleaner):
         bugid = str(bug["id"])
         data[bugid] = {
             "rev_ids": rev_ids,
+            "product": bug["product"],
+            "component": bug["component"],
         }
         return bug
 
@@ -151,6 +151,8 @@ class InactivePatchAuthors(BzCleaner):
             "attachments.is_obsolete",
             "product",
             "component",
+            "assigned_to",
+            "triage_owner",
         ]
         params = {
             "include_fields": fields,

--- a/bugbot/rules/inactive_patch_author.py
+++ b/bugbot/rules/inactive_patch_author.py
@@ -28,7 +28,7 @@ class InactivePatchAuthors(BzCleaner):
         return "Bugs with inactive patch authors"
 
     def columns(self):
-        return ["id", "summary", "authors"]
+        return ["id", "summary", "revisions"]
 
     def get_bugs(self, date="today", bug_ids=[], chunk_size=None):
         bugs = super().get_bugs(date, bug_ids, chunk_size)

--- a/bugbot/rules/inactive_patch_author.py
+++ b/bugbot/rules/inactive_patch_author.py
@@ -40,11 +40,8 @@ class InactivePatchAuthors(BzCleaner, Nag):
         bugs = super().get_bugs(date, bug_ids, chunk_size)
 
         rev_ids = {rev_id for bug in bugs.values() for rev_id in bug["rev_ids"]}
-        try:
-            inactive_authors = self._get_inactive_patch_authors(list(rev_ids))
-        except Exception as e:
-            logging.error(f"Error fetching inactive patch authors: {e}")
-            inactive_authors = {}
+
+        inactive_authors = self._get_inactive_patch_authors(list(rev_ids))
 
         for bugid, bug in list(bugs.items()):
             inactive_patches = [

--- a/bugbot/rules/inactive_patch_author.py
+++ b/bugbot/rules/inactive_patch_author.py
@@ -108,8 +108,6 @@ class InactivePatchAuthors(BzCleaner, Nag):
             for revision in self._fetch_revisions(_rev_ids):
                 author_phid = revision["fields"]["authorPHID"]
                 created_at = revision["fields"]["dateCreated"]
-                # if author_phid == "PHID-USER-eltrc7x5oplwzfguutrb":
-                #     continue
                 revisions.append(
                     {
                         "rev_id": revision["id"],

--- a/bugbot/rules/inactive_patch_author.py
+++ b/bugbot/rules/inactive_patch_author.py
@@ -105,23 +105,19 @@ class InactivePatchAuthors(BzCleaner, Nag):
         revisions: List[dict] = []
 
         for _rev_ids in Connection.chunks(rev_ids, PHAB_CHUNK_SIZE):
-            try:
-                for revision in self._fetch_revisions(_rev_ids):
-                    author_phid = revision["fields"]["authorPHID"]
-                    created_at = revision["fields"]["dateCreated"]
-                    # if author_phid == "PHID-USER-eltrc7x5oplwzfguutrb":
-                    #     continue
-                    revisions.append(
-                        {
-                            "rev_id": revision["id"],
-                            "author_phid": author_phid,
-                            "created_at": created_at,
-                            "status": revision["fields"]["status"]["value"],
-                        }
-                    )
-            except Exception as e:
-                logging.error(f"Error fetching revisions: {e}")
-                continue
+            for revision in self._fetch_revisions(_rev_ids):
+                author_phid = revision["fields"]["authorPHID"]
+                created_at = revision["fields"]["dateCreated"]
+                # if author_phid == "PHID-USER-eltrc7x5oplwzfguutrb":
+                #     continue
+                revisions.append(
+                    {
+                        "rev_id": revision["id"],
+                        "author_phid": author_phid,
+                        "created_at": created_at,
+                        "status": revision["fields"]["status"]["value"],
+                    }
+                )
 
         user_phids = set()
 

--- a/bugbot/rules/inactive_patch_author.py
+++ b/bugbot/rules/inactive_patch_author.py
@@ -1,0 +1,89 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from typing import Dict
+
+from libmozdata.connection import Connection
+from libmozdata.phabricator import PhabricatorAPI
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+from bugbot import utils
+from bugbot.bzcleaner import BzCleaner
+from bugbot.user_activity import PHAB_CHUNK_SIZE, UserActivity, UserStatus
+
+
+class InactivePatchAuthor(BzCleaner):
+    """Bugs with patches from inactive authors"""
+
+    def __init__(self):
+        """Constructor"""
+        super(InactivePatchAuthor, self).__init__()
+        self.phab = PhabricatorAPI(utils.get_login_info()["phab_api_key"])
+        self.user_activity = UserActivity(phab=self.phab)
+
+    def description(self):
+        return "Bugs with patches from inactive authors"
+
+    def columns(self):
+        return ["id", "summary", "author"]
+
+    def get_bugs(self, date="today", bug_ids=[], chunk_size=None):
+        bugs = super().get_bugs(date, bug_ids, chunk_size)
+        rev_ids = {rev_id for bug in bugs.values() for rev_id in bug["rev_ids"]}
+        revisions = self._get_revisions_with_inactive_authors(list(rev_ids))
+
+        for bugid, bug in list(bugs.items()):
+            inactive_authors = [
+                revisions[rev_id] for rev_id in bug["rev_ids"] if rev_id in revisions
+            ]
+            if inactive_authors:
+                bug["authors"] = inactive_authors
+                self._unassign_inactive_authors(bugid, inactive_authors)
+            else:
+                del bugs[bugid]
+
+        self.query_url = utils.get_bz_search_url({"bug_id": ",".join(bugs.keys())})
+        return bugs
+
+    def _unassign_inactive_authors(self, bugid: str, inactive_authors: list) -> None:
+        comment = "The author of this patch has been inactive. The patch has been unassigned for others to take over."
+        for author in inactive_authors:
+            self.phab.request(
+                "differential.revision.edit",
+                {
+                    "transactions": [{"type": "authorPHID", "value": None}],
+                    "objectIdentifier": author["rev_id"],
+                },
+            )
+            self.autofix_changes[bugid] = {"comment": {"body": comment}}
+
+    def _get_revisions_with_inactive_authors(self, rev_ids: list) -> Dict[int, dict]:
+        revisions = []
+        for _rev_ids in Connection.chunks(rev_ids, PHAB_CHUNK_SIZE):
+            for revision in self._fetch_revisions(_rev_ids):
+                revisions.append(revision)
+
+        user_phids = {revision["fields"]["authorPHID"] for revision in revisions}
+        users = self.user_activity.get_phab_users_with_status(list(user_phids))
+
+        result = {}
+        for revision in revisions:
+            author_info = users[revision["fields"]["authorPHID"]]
+            if author_info["status"] != UserStatus.ACTIVE:
+                result[revision["id"]] = {
+                    "rev_id": revision["id"],
+                    "title": revision["fields"]["title"],
+                    "author": author_info,
+                }
+        return result
+
+    @retry(wait=wait_exponential(min=4), stop=stop_after_attempt(5))
+    def _fetch_revisions(self, ids: list):
+        return self.phab.request(
+            "differential.revision.search", constraints={"ids": ids}
+        )["data"]
+
+
+if __name__ == "__main__":
+    InactivePatchAuthor().run()

--- a/bugbot/user_activity.py
+++ b/bugbot/user_activity.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import logging
 from datetime import timedelta
 from enum import Enum, auto
 from typing import Iterable, List, Optional
@@ -14,6 +15,8 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 
 from bugbot import utils
 from bugbot.people import People
+
+logging.basicConfig(level=logging.DEBUG)
 
 # The chunk size here should not be more than 100; which is the maximum number of
 # items that Phabricator could return in one response.
@@ -264,25 +267,31 @@ class UserActivity:
         # will rely on the calendar from phab.
         for _user_phids in Connection.chunks(user_phids, PHAB_CHUNK_SIZE):
             for phab_user in self._fetch_phab_users(_user_phids):
-                user = users[phab_user["phid"]]
-                phab_status = self._get_status_from_phab_user(phab_user)
-                if phab_status:
-                    user["status"] = phab_status
+                try:
+                    user = users[phab_user["phid"]]
+                    phab_status = self._get_status_from_phab_user(phab_user)
+                    if phab_status:
+                        user["status"] = phab_status
 
-                elif user["status"] in (
-                    UserStatus.ABSENT,
-                    UserStatus.INACTIVE,
-                ) and self.is_active_on_phab(phab_user["phid"]):
-                    user["status"] = UserStatus.ACTIVE
+                    elif user["status"] in (
+                        UserStatus.ABSENT,
+                        UserStatus.INACTIVE,
+                    ) and self.is_active_on_phab(phab_user["phid"]):
+                        user["status"] = UserStatus.ACTIVE
 
-                if not keep_active and user["status"] == UserStatus.ACTIVE:
-                    del users[phab_user["phid"]]
+                    if not keep_active and user["status"] == UserStatus.ACTIVE:
+                        del users[phab_user["phid"]]
+                        continue
+
+                    user["phab_username"] = phab_user["fields"]["username"]
+                    user["unavailable_until"] = phab_user["attachments"][
+                        "availability"
+                    ]["until"]
+                except Exception as e:
+                    logging.error(
+                        f"Error fetching inactive patch authors: '{phab_user['phid']}' - {str(e)}"
+                    )
                     continue
-
-                user["phab_username"] = phab_user["fields"]["username"]
-                user["unavailable_until"] = phab_user["attachments"]["availability"][
-                    "until"
-                ]
 
         return users
 

--- a/bugbot/user_activity.py
+++ b/bugbot/user_activity.py
@@ -287,7 +287,7 @@ class UserActivity:
                     user["unavailable_until"] = phab_user["attachments"][
                         "availability"
                     ]["until"]
-                except Exception as e:
+                except KeyError as e:
                     logging.error(
                         f"Error fetching inactive patch authors: '{phab_user['phid']}' - {str(e)}"
                     )

--- a/templates/inactive_patch_author.html
+++ b/templates/inactive_patch_author.html
@@ -1,0 +1,31 @@
+<p>The following {{ plural('bug has', data, pword='bugs have') }} patches with inactive authors:</p>
+<table {{ table_attrs }}>
+    <thead>
+        <tr>
+            <th>Bug</th>
+            <th>Summary</th>
+            <th>Patches</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for i, (bugid, summary, revisions) in enumerate(data) -%}
+            <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
+            {% endif -%}
+            >
+            <td {% if bugid in no_manager %}style="background:red;"{% endif %}>
+                <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
+            </td>
+            <td>{{ summary | e }}</td>
+            <td>
+                <ul style="padding: 0; margin: 0">
+                    {% for rev in revisions -%}
+                        <li>
+                            <a href="https://phabricator.services.mozilla.com/D{{ rev['rev_id'] }}">D{{ rev['rev_id'] }}</a>
+                        </li>
+                    {% endfor -%}
+                </ul>
+            </td>
+        </tr>
+    {% endfor -%}
+</tbody>
+</table>

--- a/templates/inactive_patch_author.html
+++ b/templates/inactive_patch_author.html
@@ -16,15 +16,6 @@
                 <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
             </td>
             <td>{{ summary | e }}</td>
-            <!-- <td>
-                <ul style="padding: 0; margin: 0">
-                    {% for rev in revisions -%}
-                        <li>
-                            <a href="https://phabricator.services.mozilla.com/D{{ rev['rev_id'] }}">D{{ rev['rev_id'] }}</a>
-                        </li>
-                    {% endfor -%}
-                </ul>
-            </td> -->
         </tr>
     {% endfor -%}
 </tbody>

--- a/templates/inactive_patch_author.html
+++ b/templates/inactive_patch_author.html
@@ -8,7 +8,7 @@
         </tr>
     </thead>
     <tbody>
-        {% for i, (bugid, summary, revisions) in enumerate(data) -%}
+        {% for i, (bugid, summary) in enumerate(data) -%}
             <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
             {% endif -%}
             >
@@ -16,7 +16,7 @@
                 <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ bugid }}">{{ bugid }}</a>
             </td>
             <td>{{ summary | e }}</td>
-            <td>
+            <!-- <td>
                 <ul style="padding: 0; margin: 0">
                     {% for rev in revisions -%}
                         <li>
@@ -24,7 +24,7 @@
                         </li>
                     {% endfor -%}
                 </ul>
-            </td>
+            </td> -->
         </tr>
     {% endfor -%}
 </tbody>


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
Resolves #1532.

Introduces a new rule to detect and unassign inactive patch authors on Phabricator.

If the patch is not already closed, it will be abandoned.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [x] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
