### PR TITLE
[New Rule] Needinfo when a bug is pending sec-approval but not all tracking flags are set

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,5 +61,3 @@ repos:
   - repo: meta
     hooks:
       - id: check-useless-excludes
-default_language_version:
-  python: python3.10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,3 +61,5 @@ repos:
   - repo: meta
     hooks:
       - id: check-useless-excludes
+default_language_version:
+  python: python3.10

--- a/bugbot/rules/pending_sec_no_tracking.py
+++ b/bugbot/rules/pending_sec_no_tracking.py
@@ -66,6 +66,15 @@ class SecurityApprovalTracking(BzCleaner):
             "f3": "flagtypes.name",
             "o3": "substring",
             "v3": "sec-approval?",
+            "f4": "cf_status_firefox_nightly",
+            "o4": "equals",
+            "v4": "---",
+            "f5": "cf_status_firefox_beta",
+            "o5": "equals",
+            "v5": "---",
+            "f6": "cf_status_firefox_release",
+            "o6": "equals",
+            "v6": "---",
         }
 
         return params

--- a/bugbot/rules/pending_sec_no_tracking.py
+++ b/bugbot/rules/pending_sec_no_tracking.py
@@ -45,8 +45,7 @@ class SecurityApprovalTracking(BzCleaner):
     def get_bz_params(self, date):
         start_date, _ = self.get_dates(date)
 
-        self.status = utils.get_flag(self.version, "status", self.channel)
-        self.tracking = utils.get_flag(self.version, "tracking", self.channel)
+        status = utils.get_flag(self.version, "status", self.channel)
         fields = [
             "id",
             "assigned_to",
@@ -60,7 +59,7 @@ class SecurityApprovalTracking(BzCleaner):
             "f1": "creation_ts",
             "o1": "greaterthan",
             "v1": start_date,
-            "f2": self.status,
+            "f2": status,
             "o2": "anywords",
             "n2": "1",
             "v2": ",".join(["unaffected", "affected"]),

--- a/bugbot/rules/pending_sec_no_tracking.py
+++ b/bugbot/rules/pending_sec_no_tracking.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from libmozdata.bugzilla import Bugzilla
 
 from bugbot import utils
 from bugbot.bzcleaner import BzCleaner
@@ -37,19 +36,6 @@ class SecurityApprovalTracking(BzCleaner):
 
         return bug
 
-    def get_bugs(self, date="today", bug_ids=[], chunk_size=None):
-        bugs = super().get_bugs(date, bug_ids, chunk_size)
-
-        Bugzilla(
-            bugs.keys(),
-            include_fields=self.fields,
-            bughandler=self.handle_bug,
-            bugdata=bugs,
-        ).wait()
-
-        self.extra_ni = bugs
-        return bugs
-
     def get_extra_for_needinfo_template(self):
         return self.extra_ni
 
@@ -61,17 +47,15 @@ class SecurityApprovalTracking(BzCleaner):
 
         self.status = utils.get_flag(self.version, "status", self.channel)
         self.tracking = utils.get_flag(self.version, "tracking", self.channel)
-        self.fields = [
+        fields = [
             "id",
             "assigned_to",
             "nickname",
             "flags",
-            self.tracking,
-            self.status,
         ]
 
         params = {
-            "include_fields": self.fields,
+            "include_fields": fields,
             "resolution": "---",
             "f1": "creation_ts",
             "o1": "greaterthan",

--- a/bugbot/rules/pending_sec_no_tracking.py
+++ b/bugbot/rules/pending_sec_no_tracking.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from libmozdata import utils as lmdutils
 from libmozdata.bugzilla import Bugzilla
 
 from bugbot import utils
@@ -58,7 +57,8 @@ class SecurityApprovalTracking(BzCleaner):
         return ["id", "summary", "assignee"]
 
     def get_bz_params(self, date):
-        date = lmdutils.get_date_ymd(date)
+        start_date, _ = self.get_dates(date)
+
         self.status = utils.get_flag(self.version, "status", self.channel)
         self.tracking = utils.get_flag(self.version, "tracking", self.channel)
         self.fields = [
@@ -73,13 +73,16 @@ class SecurityApprovalTracking(BzCleaner):
         params = {
             "include_fields": self.fields,
             "resolution": "---",
-            "f1": self.status,
-            "o1": "anywords",
-            "n1": "1",
-            "v1": ",".join(["unaffected", "affected"]),
-            "f2": "flagtypes.name",
-            "o2": "substring",
-            "v2": "sec-approval?",
+            "f1": "creation_ts",
+            "o1": "greaterthan",
+            "v1": start_date,
+            "f2": self.status,
+            "o2": "anywords",
+            "n2": "1",
+            "v2": ",".join(["unaffected", "affected"]),
+            "f3": "flagtypes.name",
+            "o3": "substring",
+            "v3": "sec-approval?",
         }
 
         return params

--- a/bugbot/rules/pending_sec_no_tracking.py
+++ b/bugbot/rules/pending_sec_no_tracking.py
@@ -1,0 +1,94 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from libmozdata import utils as lmdutils
+from libmozdata.bugzilla import Bugzilla
+
+from bugbot import utils
+from bugbot.bzcleaner import BzCleaner
+
+
+class SecurityApprovalTracking(BzCleaner):
+    def __init__(self, channel):
+        super().__init__()
+        self.channel = channel
+        if not self.init_versions():
+            return
+
+        self.version = self.versions[channel] if self.versions else None
+
+        self.extra_ni = None
+
+    def description(self):
+        return "Bugs with attachments pending security approval and incomplete tracking flags"
+
+    def handle_bug(self, bug, data):
+        # Assuming these bugs are bugs that do not have a status flag set to either "affected" or "unaffected"
+        bugid = str(bug["id"])
+        data[bugid] = {
+            "id": bugid,
+            "summary": bug["summary"],
+            "assignee": bug["assigned_to"],
+        }
+        self.add_auto_ni(
+            bugid,
+            {"mail": bug["assigned_to"], "nickname": bug["assigned_to_detail"]["nick"]},
+        )
+
+        return bug
+
+    def get_bugs(self, date="today", bug_ids=[], chunk_size=None):
+        bugs = super().get_bugs(date, bug_ids, chunk_size)
+
+        Bugzilla(
+            bugs.keys(),
+            include_fields=self.fields,
+            bughandler=self.handle_bug,
+            bugdata=bugs,
+        ).wait()
+
+        self.extra_ni = bugs
+        return bugs
+
+    def get_extra_for_needinfo_template(self):
+        return self.extra_ni
+
+    def columns(self):
+        return ["id", "summary", "assignee"]
+
+    def get_bz_params(self, date):
+        date = lmdutils.get_date_ymd(date)
+        self.status = utils.get_flag(self.version, "status", self.channel)
+        self.tracking = utils.get_flag(self.version, "tracking", self.channel)
+        self.fields = [
+            "id",
+            "assigned_to",
+            "nickname",
+            "flags",
+            self.tracking,
+            self.status,
+        ]
+
+        # TODO: include the custom script to search for open bugs with sec-approval?
+        # https://bugzilla.mozilla.org/buglist.cgi?cmdtype=dorem&remaction=run&namedcmd=open%20bugs%20with%20sec-approval%3F&sharer_id=75935
+
+        params = {
+            "include_fields": self.fields,
+            "resolution": "---",
+            "f1": self.status,
+            "o1": "anywords",
+            "n1": "1",
+            "v1": ",".join(["unaffected", "affected"]),
+            "f5": self.status,
+            "o5": "changedafter",
+            "v5": "-5d",
+        }
+
+        return params
+
+
+if __name__ == "__main__":
+    SecurityApprovalTracking("beta").run()
+    SecurityApprovalTracking("central").run()
+    SecurityApprovalTracking("esr").run()

--- a/bugbot/rules/pending_sec_no_tracking.py
+++ b/bugbot/rules/pending_sec_no_tracking.py
@@ -70,9 +70,6 @@ class SecurityApprovalTracking(BzCleaner):
             self.status,
         ]
 
-        # TODO: include the custom script to search for open bugs with sec-approval?
-        # https://bugzilla.mozilla.org/buglist.cgi?cmdtype=dorem&remaction=run&namedcmd=open%20bugs%20with%20sec-approval%3F&sharer_id=75935
-
         params = {
             "include_fields": self.fields,
             "resolution": "---",
@@ -80,6 +77,9 @@ class SecurityApprovalTracking(BzCleaner):
             "o1": "anywords",
             "n1": "1",
             "v1": ",".join(["unaffected", "affected"]),
+            "f2": "flagtypes.name",
+            "o2": "substring",
+            "v2": "sec-approval?",
         }
 
         return params

--- a/bugbot/rules/pending_sec_no_tracking.py
+++ b/bugbot/rules/pending_sec_no_tracking.py
@@ -80,9 +80,6 @@ class SecurityApprovalTracking(BzCleaner):
             "o1": "anywords",
             "n1": "1",
             "v1": ",".join(["unaffected", "affected"]),
-            "f5": self.status,
-            "o5": "changedafter",
-            "v5": "-5d",
         }
 
         return params

--- a/templates/pending_sec_no_tracking.html
+++ b/templates/pending_sec_no_tracking.html
@@ -1,0 +1,23 @@
+<p>
+    The following {{ plural('bug has', data, pword='bugs have') }} a patch pending security approval, but the affected/unaffected status is not set for all current releases:
+</p>
+<table {{ table_attrs }}>
+    <thead>
+        <tr>
+            <th>Bug</th>
+            <th>Summary</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for i, (id, summary, assignee) in enumerate(data) -%}
+            <tr {% if i % 2 == 0 %}bgcolor="#E0E0E0"
+            {% endif -%}
+            >
+            <td>
+                <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ id }}">{{ id }}</a>
+            </td>
+            <td>{{ summary | e }}</td>
+        </tr>
+    {% endfor -%}
+</tbody>
+</table>

--- a/templates/pending_sec_no_tracking_needinfo.txt
+++ b/templates/pending_sec_no_tracking_needinfo.txt
@@ -1,0 +1,1 @@
+:{{ nickname }}, there is a patch pending security approval, however, the affected/unaffected status is not set for all current releases. Please update the status flags to correctly reflect the correct status.


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->
Resolves #2336.

Intended to needinfo bug assignees when not all current release tracking fields are set to either affected/unaffected and an attachment is pending `sec-approval`.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
