### PR TITLE
[no_severity_ni] Avoid needinfo'ing triage owners that have blocked being needinfo'd

### DIFF
--- a/bugbot/rules/workflow/no_severity_ni.py
+++ b/bugbot/rules/workflow/no_severity_ni.py
@@ -201,28 +201,58 @@ class NoSeverityNeedInfo(BzCleaner, Nag):
 
         return params
 
-    def filter_bugs(self, bugs):
-        users_info = UserActivity(include_fields=["groups", "requests"]).check_users(
-            set(bug["triage_owner"] for bug in bugs.values()),
-            keep_active=True,
-            fetch_employee_info=True,
-        )
+    def bughandler(self, bug, data):
+        """bug handler for the Bugzilla query"""
+        if bug["id"] in self.cache:
+            return
 
-        # for bug_id, bug in list(bugs.items()):
-        #     user_info = users_info[bug["triage_owner"]]
-        #     if "requests" in user_info:
-        #         if user_info["requests"]["needinfo"]["blocked"]:
-        #             del bugs[bug_id]
-        filtered_bugs = {
-            bug_id: bug
-            for bug_id, bug in bugs.items()
-            if not users_info[bug["triage_owner"]]["requests"]["needinfo"]["blocked"]
-        }
-        return filtered_bugs
+        if self.handle_bug(bug, data) is None:
+            return
+
+        bugid = str(bug["id"])
+        res = {"id": bugid}
+
+        auto_ni = self.get_mail_to_auto_ni(bug)
+        self.add_auto_ni(bugid, auto_ni)
+
+        triage_owner = bug.get("triage_owner")
+        users_info = UserActivity(include_fields=["groups", "requests"]).check_users(
+            {triage_owner}, keep_active=True, fetch_employee_info=True
+        )
+        if not (
+            triage_owner in users_info
+            and users_info[triage_owner]["requests"]["needinfo"]["blocked"]
+        ):
+            auto_ni = self.get_mail_to_auto_ni(bug)
+            self.add_auto_ni(bugid, auto_ni)
+
+        res["summary"] = self.get_summary(bug)
+
+        if self.has_assignee():
+            res["assignee"] = utils.get_name_from_user_detail(bug["assigned_to_detail"])
+
+        if self.has_needinfo():
+            s = set()
+            for flag in utils.get_needinfo(bug):
+                s.add(flag["requestee"])
+            res["needinfos"] = sorted(s)
+
+        if self.has_product_component():
+            for k in ["product", "component"]:
+                res[k] = bug[k]
+
+        if isinstance(self, Nag):
+            bug = self.set_people_to_nag(bug, res)
+            if not bug:
+                return
+
+        if bugid in data:
+            data[bugid].update(res)
+        else:
+            data[bugid] = res
 
     def get_bugs(self, *args, **kwargs):
         bugs = super().get_bugs(*args, **kwargs)
-        bugs = self.filter_bugs(bugs)
         return bugs
 
 

--- a/bugbot/rules/workflow/no_severity_ni.py
+++ b/bugbot/rules/workflow/no_severity_ni.py
@@ -211,7 +211,8 @@ class NoSeverityNeedInfo(BzCleaner, Nag):
         filtered_bugs = {
             bug_id: bug
             for bug_id, bug in bugs.items()
-            if not users_info[bug["triage_owner"]]["requests"]["needinfo"]["blocked"]
+            if "requests" in users_info[bug["triage_owner"]]
+            and not users_info[bug["triage_owner"]]["requests"]["needinfo"]["blocked"]
         }
         return filtered_bugs
 

--- a/bugbot/rules/workflow/no_severity_ni.py
+++ b/bugbot/rules/workflow/no_severity_ni.py
@@ -208,12 +208,17 @@ class NoSeverityNeedInfo(BzCleaner, Nag):
             fetch_employee_info=True,
         )
 
-        for bug_id, bug in list(bugs.items()):
-            user_info = users_info[bug["triage_owner"]]
-            if "requests" in user_info:
-                if user_info["requests"]["needinfo"]["blocked"]:
-                    del bugs[bug_id]
-        return bugs
+        # for bug_id, bug in list(bugs.items()):
+        #     user_info = users_info[bug["triage_owner"]]
+        #     if "requests" in user_info:
+        #         if user_info["requests"]["needinfo"]["blocked"]:
+        #             del bugs[bug_id]
+        filtered_bugs = {
+            bug_id: bug
+            for bug_id, bug in bugs.items()
+            if not users_info[bug["triage_owner"]]["requests"]["needinfo"]["blocked"]
+        }
+        return filtered_bugs
 
     def get_bugs(self, *args, **kwargs):
         bugs = super().get_bugs(*args, **kwargs)

--- a/bugbot/rules/workflow/no_severity_ni.py
+++ b/bugbot/rules/workflow/no_severity_ni.py
@@ -212,9 +212,6 @@ class NoSeverityNeedInfo(BzCleaner, Nag):
         bugid = str(bug["id"])
         res = {"id": bugid}
 
-        auto_ni = self.get_mail_to_auto_ni(bug)
-        self.add_auto_ni(bugid, auto_ni)
-
         triage_owner = bug.get("triage_owner")
         users_info = UserActivity(include_fields=["groups", "requests"]).check_users(
             {triage_owner}, keep_active=True, fetch_employee_info=True


### PR DESCRIPTION
Resolves #2053.

Adds an additional check to delete bugs where the triage owner has requested to block needinfos.


## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
