### PR TITLE
[component] Changed classification from Fenix::General to GeckoView::General

### DIFF
--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -128,7 +128,10 @@ class Component(BzCleaner):
                 confidence = data["prob"][data["index"]]
 
                 if confidence > self.fenix_confidence_threshold:
-                    data["class"] = f"Fenix::{data['class']}"
+                    if data["class"] == "General":
+                        data["class"] = "GeckoView::General"
+                    else:
+                        data["class"] = f"Fenix::{data['class']}"
                     bugs[bug_id] = data
 
         results = {}


### PR DESCRIPTION
Resolves mozilla/bugbug#4682.

When the Fenix component model returns `General`, it ensures that it is classified as `GeckoView::General` not `Fenix::General`.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
