### PR TITLE
Release notes rule

### DIFF
--- a/bugbot/rules/release_notes.py
+++ b/bugbot/rules/release_notes.py
@@ -1,0 +1,60 @@
+from jinja2 import Environment, FileSystemLoader
+
+from bugbot import mail, utils
+from bugbot.bzcleaner import BzCleaner
+from bugbot.nag_me import Nag
+
+
+class ReleaseNotes(BzCleaner, Nag):
+    def __init__(self):
+        super().__init__()
+
+    def description(self):
+        return "Weekly Release Notes Digest"
+
+    def template(self):
+        return "release_notes.html"
+
+    def get_email_data(self, date: str):
+        # Simulate API call to fetch release notes
+        return [
+            {"title": "New Dark Mode in Settings", "link": "https://example.com/1"},
+            {
+                "title": "Performance Improvements in Rendering",
+                "link": "https://example.com/2",
+            },
+            {"title": "Security Fixes", "link": "https://example.com/3"},
+        ]
+
+    def send_email(self, date="today"):
+        login_info = utils.get_login_info()
+        data = self.get_email_data(date)
+        if data:
+            title, body = self.get_email(date, data)
+            receivers = utils.get_config(self.name(), "receivers")
+            mail.send(
+                login_info["ldap_username"],
+                receivers,
+                title,
+                body,
+                html=True,
+                login=login_info,
+                dryrun=self.dryrun,
+            )
+
+    def get_email(self, date: str, data: dict, preamble: str = ""):
+        env = Environment(loader=FileSystemLoader("templates"))
+        template = env.get_template(self.template())
+        message = template.render(date=date, data=data)
+
+        common = env.get_template("common.html")
+        body = common.render(
+            preamble=preamble,
+            message=message,
+            query_url=None,
+        )
+        return self.get_email_subject(date), body
+
+
+if __name__ == "__main__":
+    ReleaseNotes().run()

--- a/configs/rules.json
+++ b/configs/rules.json
@@ -478,5 +478,9 @@
   },
   "perfalert_resolved_regression": {
     "additional_receivers": ["perfalert-activity@mozilla.com", "sparky@mozilla.com"]
+  },
+  "release_notes": {
+    "must_run": ["Mon"],
+    "receivers": ["release-mgmt@mozilla.com"]
   }
 }

--- a/configs/rules.json
+++ b/configs/rules.json
@@ -481,6 +481,7 @@
   },
   "release_notes": {
     "must_run": ["Mon"],
-    "receivers": ["release-mgmt@mozilla.com"]
+    "receivers": ["release-mgmt@mozilla.com"],
+    "weeks_lookup": 4
   }
 }

--- a/templates/release_notes.html
+++ b/templates/release_notes.html
@@ -1,0 +1,8 @@
+<h2>Release Notes Summary for {{ date }}</h2>
+<ul>
+    {% for note in data %}
+        <li>
+            <a href="{{ note.link }}">{{ note.title }}</a>
+        </li>
+    {% endfor %}
+</ul>


### PR DESCRIPTION
Rule that calls the cloud function to generate release notes. Cannot be merged until the cloud function is deployed.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
