### PR TITLE
Add [webcompat:japan] to whiteboard for bugs in Japan Top 1000

### DIFF
--- a/bugbot/rules/webcompat_sightline.py
+++ b/bugbot/rules/webcompat_sightline.py
@@ -60,15 +60,13 @@ class WebcompatSightline(BzCleaner):
         self.metric_bugs = self.get_metric_bugs()
         # Get all bugs that either have, or should have, the [webcompat:sightline]
         # whiteboard entry
-        query = {
+        return {
             "include_fields": fields,
             "j_top": "OR",
             "f1": "bug_id",
             "o1": "anyexact",
             "v1": ",".join(str(item) for item in self.metric_bugs.keys()),
         }
-
-        return query
 
     def get_metric_bugs(self) -> Mapping[int, Mapping[MetricType, bool]]:
         project = "moz-fx-dev-dschubert-wckb"


### PR DESCRIPTION
This updates the WebcompatSightline rule to be more generic and allow providing labels corresponding to multiple subsets of the webcompat bugs that we're interested in.

Concretely it adds the capability to label bugs in the Japan Top 1000 as `[webcompat:japan]` in the whiteboard.

To avoid creating over-long bugzilla queries, rather than selecting all bugs that are in the various metrics by number, we select from the database only the bugs where the last recorded whiteboard value doesn't match the expectations given its metric status. This is conservative: although the bugzilla view of the whiteboard may be outdated, we check again against the current value before making any changes.

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
