### PR TITLE
Temporary disable needinfo requests on jmathies

### DIFF
--- a/configs/rules.json
+++ b/configs/rules.json
@@ -274,6 +274,7 @@
     ]
   },
   "no_severity_ni": {
+    "needinfo_skiplist": ["jmathies@mozilla.com"],
     "weeks_lookup": 2,
     "escalation": {
       "default": {


### PR DESCRIPTION
<!---
Please describe why and what this Pull Request is doing
-->

We currently have more than 72 needinfos requests that will be added on jmathies, most of which were cleared without response recently. So that will be more noise than a helpful reminder. We should enable it again later when this is sorted out.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
