### PR TITLE
Revert "Temporary disable needinfo requests on jmathies"

### DIFF
--- a/configs/rules.json
+++ b/configs/rules.json
@@ -274,7 +274,6 @@
     ]
   },
   "no_severity_ni": {
-    "needinfo_skiplist": ["jmathies@mozilla.com"],
     "weeks_lookup": 2,
     "escalation": {
       "default": {


### PR DESCRIPTION
Reverts mozilla/bugbot#2756

Jim is OK with re-enabling it.