### PR TITLE
Revert "[variant_expiration] Handle 'None' string as never expiration…

### DIFF
--- a/bugbot/rules/variant_expiration.py
+++ b/bugbot/rules/variant_expiration.py
@@ -143,7 +143,7 @@ class VariantExpiration(BzCleaner, Nag):
         for variant in variants.values():
             expiration = variant["expiration"]
 
-            if expiration == "never" or expiration == "None":
+            if expiration == "never":
                 expiration = datetime.max
 
             variant["expiration"] = lmdutils.get_date_ymd(expiration)


### PR DESCRIPTION
This reverts commit 03519dc60e204378731c5878368508314e1d1d66.

Reverting in favour of [D285529](https://phabricator.services.mozilla.com/D285529) and [D285598](https://phabricator.services.mozilla.com/D285598) as suggested in https://github.com/mozilla/bugbot/pull/2821#discussion_r2874029313.

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
