### PR TITLE
Revert "Enable tool to automatically set "access" keywords on bugs that are presumably accessibility bugs"

### DIFF
--- a/bugbot/rules/accessibilitybug.py
+++ b/bugbot/rules/accessibilitybug.py
@@ -38,16 +38,6 @@ class AccessibilityBug(BzCleaner):
             "f3": "keywords",
             "o3": "notsubstring",
             "v3": "access",
-            "j4": "AND",
-            "n4": 1,
-            "f4": "OP",
-            "f5": "product",
-            "o5": "equals",
-            "v5": "Firefox",
-            "f6": "component",
-            "o6": "equals",
-            "v6": "Disability Access",
-            "f7": "CP",
         }
 
     def get_bugs(self, date="today", bug_ids=[]):

--- a/configs/rules.json
+++ b/configs/rules.json
@@ -352,8 +352,7 @@
   },
   "accessibilitybug": {
     "max_days_in_cache": 7,
-    "days_lookup": 7,
-    "additional_receivers": ["jteh@mozilla.com"]
+    "days_lookup": 7
   },
   "component": {
     "confidence_threshold": 0.35,

--- a/scripts/cron_run_weekdays.sh
+++ b/scripts/cron_run_weekdays.sh
@@ -200,7 +200,4 @@ python -m bugbot.rules.severity_high_performance_impact --production
 # Request potential missing info when a bug is moved to Core::Performance
 python -m bugbot.rules.moved_to_performance --production
 
-# Try to detect potential accessibility bugs using bugbug
-python -m bugbot.rules.accessibilitybug --production
-
 source ./scripts/cron_common_end.sh


### PR DESCRIPTION
Reverts mozilla/bugbot#2837

Fixes #2843