### PR TITLE
Move bugs for which bugbug is not confident enough in Firefox::General for human triage

### DIFF
--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -220,14 +220,12 @@ class Component(BzCleaner):
             if self.frequency == "daily":
                 results[bug_id] = result
 
-            autofixed = False
             if prob[index] >= self.component_confidence_threshold:
                 self.autofix_component[bug_id] = {
                     "product": suggested_product,
                     "component": suggested_component,
                 }
-
-                autofixed = True
+                result["autofixed"] = True
             # Move Firefox::Untriaged bugs with no/low-confidence predictions to Firefox::General.
             elif bug["product"] == "Firefox" and bug["component"] == "Untriaged":
                 self.autofix_component[bug_id] = {
@@ -236,11 +234,9 @@ class Component(BzCleaner):
                     "suggested_product": suggested_product,
                     "suggested_component": suggested_component,
                 }
-                autofixed = True
-
-            if autofixed:
                 result["autofixed"] = True
 
+            if result["autofixed"]:
                 # In hourly mode, we send an email with only the bugs we acted upon.
                 if self.frequency == "hourly":
                     results[bug_id] = result

--- a/bugbot/rules/component.py
+++ b/bugbot/rules/component.py
@@ -220,12 +220,25 @@ class Component(BzCleaner):
             if self.frequency == "daily":
                 results[bug_id] = result
 
+            autofixed = False
             if prob[index] >= self.component_confidence_threshold:
                 self.autofix_component[bug_id] = {
                     "product": suggested_product,
                     "component": suggested_component,
                 }
 
+                autofixed = True
+            # Move Firefox::Untriaged bugs with no/low-confidence predictions to Firefox::General.
+            elif bug["product"] == "Firefox" and bug["component"] == "Untriaged":
+                self.autofix_component[bug_id] = {
+                    "product": "Firefox",
+                    "component": "General",
+                    "suggested_product": suggested_product,
+                    "suggested_component": suggested_component,
+                }
+                autofixed = True
+
+            if autofixed:
                 result["autofixed"] = True
 
                 # In hourly mode, we send an email with only the bugs we acted upon.
@@ -275,6 +288,11 @@ class Component(BzCleaner):
                         "cc": {"add": cc},
                         "comment": {
                             "body": f"The [Bugbug](https://github.com/mozilla/bugbug/) bot thinks this bug should belong to the '{data['product']}::{data['component']}' component, and is moving the bug to that component. Please correct in case you think the bot is wrong."
+                            if (
+                                data["product"] != "Firefox"
+                                or data["component"] != "General"
+                            )
+                            else f"The [Bugbug](https://github.com/mozilla/bugbug/) bot thinks this bug should belong to the '{data['suggested_product']}::{data['suggested_component']}' component, but is not confident enough to move the bug to that component."
                         },
                     }
                 )


### PR DESCRIPTION
Fixes #2857 

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
