### PR TITLE
Don't add blocks relationship to pdf.js update bugs that have been closed as DUPLICATE

### DIFF
--- a/bugbot/rules/pdfjs_update.py
+++ b/bugbot/rules/pdfjs_update.py
@@ -43,6 +43,10 @@ class PDFJSUpdate(BzCleaner):
             "f3": "blocked",
             "o3": "changedby",
             "v3": utils.get_config("common", "bot_bz_mail")[0],
+            "n4": 1,
+            "f4": "resolution",
+            "o4": "equals",
+            "v4": "DUPLICATE",
         }
 
     def set_autofix(self, bugs):


### PR DESCRIPTION
We want to avoid cases like https://bugzilla.mozilla.org/show_bug.cgi?id=2035074#a64913_575867.

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
