### PR TITLE
not_landed: reduce threshold from 2 weeks to 1 week

### DIFF
--- a/bugbot/rules/not_landed.py
+++ b/bugbot/rules/not_landed.py
@@ -23,13 +23,13 @@ PHAB_URL_PAT = re.compile(r"https://phabricator\.services\.mozilla\.com/D([0-9]+
 class NotLanded(BzCleaner):
     def __init__(self):
         super(NotLanded, self).__init__()
-        self.nweeks = utils.get_config(self.name(), "number_of_weeks", 2)
+        self.nweeks = utils.get_config(self.name(), "number_of_weeks", 1)
         self.nyears = utils.get_config(self.name(), "number_of_years", 2)
         self.phab = PhabricatorAPI(utils.get_login_info()["phab_api_key"])
         self.extra_ni = {}
 
     def description(self):
-        return "Open bugs with no activity for {} weeks and a r+ patch which hasn't landed".format(
+        return "Open bugs with no activity for {} week(s) and a r+ patch which hasn't landed".format(
             self.nweeks
         )
 

--- a/configs/rules.json
+++ b/configs/rules.json
@@ -123,7 +123,7 @@
     "must_run": ["Mon"]
   },
   "not_landed": {
-    "number_of_weeks": 2,
+    "number_of_weeks": 1,
     "number_of_years": 2
   },
   "ni_from_manager": {


### PR DESCRIPTION
Reduce the inactivity threshold for r+ patches that haven't landed from 2 weeks to 1 week to catch stale patches earlier.

Changes:
- Default `number_of_weeks` from 2 → 1 (both in code and config)
- Use `week(s)` in description to handle singular/plural correctly