### PR TITLE
newbie_with_ni: reduce inactivity threshold from 14 to 7 days

### DIFF
--- a/configs/rules.json
+++ b/configs/rules.json
@@ -113,7 +113,7 @@
     "sec": false
   },
   "newbie_with_ni": {
-    "number_of_days": 14,
+    "number_of_days": 7,
     "number_of_comments": 2
   },
   "assignee_no_login": {


### PR DESCRIPTION
Nag newbie assignees after 7 days of inactivity instead of 14, to get faster feedback on assigned bugs.