### PR TITLE
no_severity_ni: reduce lookup window from 2 weeks to 1 week

### DIFF
--- a/configs/rules.json
+++ b/configs/rules.json
@@ -274,7 +274,7 @@
     ]
   },
   "no_severity_ni": {
-    "weeks_lookup": 2,
+    "weeks_lookup": 1,
     "escalation": {
       "default": {
         "[0;+∞[": {


### PR DESCRIPTION
Triage severity faster by needinfoing component owners after 1 week instead of 2 when bugs have no severity set.