### PR TITLE
Add types to bzcleaner.py

### DIFF
--- a/bugbot/bzcleaner.py
+++ b/bugbot/bzcleaner.py
@@ -2,14 +2,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# mypy: disallow-untyped-defs
+
 import argparse
 import logging
 import os
 import sys
 import time
 from collections import defaultdict
+from collections.abc import Iterable, Mapping
 from datetime import datetime
-from typing import Dict, List
+from typing import Any, cast
 
 from dateutil.relativedelta import relativedelta
 from jinja2 import Environment, FileSystemLoader, Template
@@ -21,11 +24,17 @@ from bugbot import db, logger, logger_extra, mail, utils
 from bugbot.cache import Cache
 from bugbot.nag_me import Nag
 
+BzParams = dict[str, str | int | list[str] | list[int]]
+EmailData = list[tuple[Any, ...]] | list[dict[Any, Any]]
+Bug = Mapping[str, Any]
+
 
 class TooManyChangesError(Exception):
     """Exception raised when the rule is trying to apply too many changes"""
 
-    def __init__(self, bugs, changes, max_changes):
+    def __init__(
+        self, bugs: dict[str, Bug], changes: dict[str, Any], max_changes: int
+    ) -> None:
         message = f"The rule has been aborted because it was attempting to apply changes on {len(changes)} bugs. Max is {max_changes}."
         super().__init__(message)
         self.bugs = bugs
@@ -50,73 +59,76 @@ class BzCleaner(object):
     no_bugmail: bool = False
     normal_changes_max: int = 50
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(BzCleaner, self).__init__()
         self._set_rule_name()
-        self.apply_autofix = True
-        self.has_autofix = False
-        self.autofix_changes = {}
-        self.quota_actions = defaultdict(list)
-        self.no_manager = set()
-        self.auto_needinfo = {}
-        self.has_flags = False
+        self.apply_autofix: bool = True
+        self.has_autofix: bool = False
+        self.autofix_changes: dict[str, Any] = {}
+        self.quota_actions: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        self.no_manager: set[str] = set()
+        self.auto_needinfo: dict[str, dict[str, Any]] = {}
+        self.extra_ni: dict[str, Any] = {}
+        self.has_flags: bool = False
         self.cache = Cache(self.name(), self.max_days_in_cache())
         self.test_mode = utils.get_config("common", "test", False)
-        self.versions = None
+        self.versions: Any = None
 
-    def _set_rule_name(self):
+    def _set_rule_name(self) -> None:
         module = sys.modules[self.__class__.__module__]
+        module_file = module.__file__
+        assert module_file is not None
         base = os.path.dirname(__file__)
         rules = os.path.join(base, "rules")
-        self.__rule_path__ = os.path.relpath(module.__file__, rules)
-        name = os.path.basename(module.__file__)
+        self.__rule_path__: str = os.path.relpath(module_file, rules)
+        name = os.path.basename(module_file)
         name = os.path.splitext(name)[0]
-        self.__rule_name__ = name
+        self.__rule_name__: str = name
 
-    def init_versions(self):
+    def init_versions(self) -> bool:
         self.versions = utils.get_checked_versions()
         return bool(self.versions)
 
-    def max_days_in_cache(self):
+    def max_days_in_cache(self) -> int:
         """Get the max number of days the data must be kept in cache"""
         return self.get_config("max_days_in_cache", -1)
 
-    def description(self):
+    def description(self) -> str:
         """Get the description for the help"""
         return ""
 
-    def name(self):
+    def name(self) -> str:
         """Get the rule name"""
         return self.__rule_name__
 
-    def get_rule_path(self):
+    def get_rule_path(self) -> str:
         """Get the rule path"""
         return self.__rule_path__
 
-    def needinfo_template_name(self):
+    def needinfo_template_name(self) -> str:
         """Get the txt template filename"""
         return self.name() + "_needinfo.txt"
 
-    def template(self):
+    def template(self) -> str:
         """Get the html template filename"""
         return self.name() + ".html"
 
-    def subject(self):
+    def subject(self) -> str:
         """Get the partial email subject"""
         return self.description()
 
-    def get_email_subject(self, date):
+    def get_email_subject(self, date: str | None) -> str:
         """Get the email subject with a date or not"""
         af = "[autofix]" if self.has_autofix else ""
         if date:
             return "[bugbot]{} {} for the {}".format(af, self.subject(), date)
         return "[bugbot]{} {}".format(af, self.subject())
 
-    def ignore_date(self):
+    def ignore_date(self) -> bool:
         """Should we ignore the date ?"""
         return False
 
-    def must_run(self, date):
+    def must_run(self, date: datetime) -> bool:
         """Check if the rule must run for this date"""
         days = self.get_config("must_run", None)
         if not days:
@@ -128,39 +140,39 @@ class BzCleaner(object):
                 return True
         return False
 
-    def has_enough_data(self):
+    def has_enough_data(self) -> bool:
         """Check if the rule has enough data to run"""
         if self.versions is None:
             # init_versions() has never been called
             return True
         return bool(self.versions)
 
-    def filter_no_nag_keyword(self):
+    def filter_no_nag_keyword(self) -> bool:
         """If True, then remove the bugs with [no-nag] in whiteboard from the bug list"""
         return True
 
-    def add_no_manager(self, bugid):
+    def add_no_manager(self, bugid: str | int) -> None:
         self.no_manager.add(str(bugid))
 
-    def has_assignee(self):
+    def has_assignee(self) -> bool:
         return False
 
-    def has_needinfo(self):
+    def has_needinfo(self) -> bool:
         return False
 
-    def get_mail_to_auto_ni(self, bug):
+    def get_mail_to_auto_ni(self, bug: Bug) -> dict[str, Any] | None:
         return None
 
-    def all_include_fields(self):
+    def all_include_fields(self) -> bool:
         return False
 
-    def get_max_ni(self):
+    def get_max_ni(self) -> int:
         return -1
 
-    def get_max_actions(self):
+    def get_max_actions(self) -> int:
         return -1
 
-    def exclude_no_action_bugs(self):
+    def exclude_no_action_bugs(self) -> bool:
         """
         If `True`, then remove bugs that have no actions from the email (e.g.,
         needinfo got ignored due to exceeding the limit). This is applied only
@@ -171,68 +183,67 @@ class BzCleaner(object):
         """
         return True
 
-    def ignore_meta(self):
+    def ignore_meta(self) -> bool:
         return False
 
-    def columns(self):
+    def columns(self) -> list[str]:
         """The fields to get for the columns in email report"""
         return ["id", "summary"]
 
-    def sort_columns(self):
+    def sort_columns(self) -> str | None:
         """Returns the key to sort columns"""
         return None
 
-    def get_dates(self, date):
+    def get_dates(self, date_str: str) -> tuple[datetime, datetime]:
         """Get the dates for the bugzilla query (changedafter and changedbefore fields)"""
-        date = lmdutils.get_date_ymd(date)
+        date = lmdutils.get_date_ymd(date_str)
+        if date is None:
+            raise ValueError(f"Invalid date string {date_str}")
         lookup = self.get_config("days_lookup", 7)
         start_date = date - relativedelta(days=lookup)
         end_date = date + relativedelta(days=1)
 
         return start_date, end_date
 
-    def get_extra_for_template(self):
+    def get_extra_for_template(self) -> Mapping[str, Any]:
         """Get extra data to put in the template"""
         return {}
 
-    def get_extra_for_needinfo_template(self):
+    def get_extra_for_needinfo_template(self) -> Mapping[str, Any]:
         """Get extra data to put in the needinfo template"""
         return {}
 
-    def get_config(self, entry, default=None):
+    def get_config(self, entry: str, default: Any = None) -> Any:
         return utils.get_config(self.name(), entry, default=default)
 
-    def get_bz_params(self, date):
+    def get_bz_params(self, date: str) -> BzParams:
         """Get the Bugzilla parameters for the search query"""
         return {}
 
-    def get_data(self):
+    def get_data(self) -> dict[str, Any]:
         """Get the data structure to use in the bughandler"""
         return {}
 
-    def get_summary(self, bug):
+    def get_summary(self, bug: Bug) -> str:
         return "..." if bug["groups"] else bug["summary"]
 
-    def get_cc_emails(self, data):
+    def get_cc_emails(self, data: EmailData) -> list[str]:
         return []
 
-    def has_default_products(self):
+    def has_default_products(self) -> bool:
         return True
 
-    def has_product_component(self):
+    def has_product_component(self) -> bool:
         return False
 
-    def get_product_component(self):
-        return self.prod_comp
-
-    def has_access_to_sec_bugs(self):
+    def has_access_to_sec_bugs(self) -> bool:
         return self.get_config("sec", True)
 
-    def handle_bug(self, bug, data):
+    def handle_bug(self, bug: Bug, data: dict[str, Any]) -> Bug | None:
         """Implement this function to get all the bugs from the query"""
         return bug
 
-    def get_db_extra(self):
+    def get_db_extra(self) -> Mapping[str, Any]:
         """Get extra information required for db insertion"""
         return {
             bugid: ni_mail
@@ -240,11 +251,11 @@ class BzCleaner(object):
             for bugid in v["bugids"]
         }
 
-    def get_auto_ni_skiplist(self):
+    def get_auto_ni_skiplist(self) -> set[str]:
         """Return a set of email addresses that should never be needinfoed"""
         return set(self.get_config("needinfo_skiplist", default=[]))
 
-    def add_auto_ni(self, bugid, data):
+    def add_auto_ni(self, bugid: str | int, data: dict[str, Any] | None) -> bool:
         if not data:
             return False
 
@@ -264,7 +275,13 @@ class BzCleaner(object):
             }
         return True
 
-    def add_prioritized_action(self, bug, quota_name, needinfo=None, autofix=None):
+    def add_prioritized_action(
+        self,
+        bug: Bug,
+        quota_name: str,
+        needinfo: dict[str, Any] | None = None,
+        autofix: dict[str, Any] | None = None,
+    ) -> None:
         """
         - `quota_name` is the key used to apply the limits, e.g., triage owner, team, or component
         """
@@ -282,10 +299,10 @@ class BzCleaner(object):
 
         self.quota_actions[quota_name].append(action)
 
-    def get_bug_sort_key(self, bug):
+    def get_bug_sort_key(self, bug: int) -> str | None:
         return None
 
-    def _populate_prioritized_actions(self, bugs):
+    def _populate_prioritized_actions(self, bugs: dict[str, Bug]) -> dict[str, Any]:
         max_actions = self.get_max_actions()
         max_ni = self.get_max_ni()
         exclude_no_action_bugs = (
@@ -337,7 +354,7 @@ class BzCleaner(object):
 
         return bugs
 
-    def bughandler(self, bug, data):
+    def bughandler(self, bug: Bug, data: dict[str, Any]) -> None:
         """bug handler for the Bugzilla query"""
         if bug["id"] in self.cache:
             return
@@ -346,7 +363,7 @@ class BzCleaner(object):
             return
 
         bugid = str(bug["id"])
-        res = {"id": bugid}
+        res: dict[str, Any] = {"id": bugid}
 
         auto_ni = self.get_mail_to_auto_ni(bug)
         self.add_auto_ni(bugid, auto_ni)
@@ -376,7 +393,7 @@ class BzCleaner(object):
         else:
             data[bugid] = res
 
-    def get_products(self):
+    def get_products(self) -> list[str]:
         return list(
             (
                 set(self.get_config("products"))
@@ -385,7 +402,7 @@ class BzCleaner(object):
             - set(self.get_config("exclude_products", []))
         )
 
-    def amend_bzparams(self, params, bug_ids):
+    def amend_bzparams(self, params: dict[str, Any], bug_ids: list[int]) -> None:
         """Amend the Bugzilla params"""
         if not self.all_include_fields():
             if "include_fields" in params:
@@ -441,7 +458,12 @@ class BzCleaner(object):
 
         self.has_flags = "flags" in params.get("include_fields", [])
 
-    def get_bugs(self, date="today", bug_ids=[], chunk_size=None):
+    def get_bugs(
+        self,
+        date: str = "today",
+        bug_ids: list[int] = [],
+        chunk_size: int | None = None,
+    ) -> dict[str, Any]:
         """Get the bugs"""
         bugs = self.get_data()
         params = self.get_bz_params(date)
@@ -469,10 +491,10 @@ class BzCleaner(object):
 
         return bugs
 
-    def commenthandler(self, bug, bugid, data):
+    def commenthandler(self, bug: Bug, bugid: str | int, data: dict[str, Any]) -> None:
         return
 
-    def _commenthandler(self, bug, bugid, data):
+    def _commenthandler(self, bug: Bug, bugid: str | int, data: dict[str, Any]) -> None:
         comments = bug["comments"]
         bugid = str(bugid)
         if self.has_last_comment_time():
@@ -483,7 +505,7 @@ class BzCleaner(object):
 
         self.commenthandler(bug, bugid, data)
 
-    def get_comments(self, bugs):
+    def get_comments(self, bugs: dict[str, Any]) -> dict[str, Any]:
         """Get the bugs comments"""
         if self.has_last_comment_time():
             bugids = self.get_list_bugs(bugs)
@@ -492,35 +514,35 @@ class BzCleaner(object):
             ).get_data().wait()
         return bugs
 
-    def has_last_comment_time(self):
+    def has_last_comment_time(self) -> bool:
         return False
 
-    def get_list_bugs(self, bugs):
+    def get_list_bugs(self, bugs: dict[str, Any]) -> list[str]:
         return [x["id"] for x in bugs.values()]
 
-    def get_documentation(self):
+    def get_documentation(self) -> str:
         return "For more information, please visit [BugBot documentation](https://wiki.mozilla.org/BugBot#{}).".format(
             self.get_rule_path().replace("/", ".2F")
         )
 
-    def has_bot_set_ni(self, bug):
+    def has_bot_set_ni(self, bug: Bug) -> bool:
         if not self.has_flags:
             raise Exception
         return utils.has_bot_set_ni(bug)
 
-    def set_needinfo(self):
+    def set_needinfo(self) -> Mapping[str, Mapping[str, Any]]:
         if not self.auto_needinfo:
             return {}
 
         template = self.get_needinfo_template()
-        res = {}
+        res: dict[str, dict[str, Any]] = {}
 
         doc = self.get_documentation()
 
         for ni_mail, info in self.auto_needinfo.items():
             nick = info["nickname"]
             for bugid in info["bugids"]:
-                data = {
+                data: dict[str, Any] = {
                     "comment": {"body": ""},
                     "flags": [
                         {
@@ -563,19 +585,19 @@ class BzCleaner(object):
 
         return template
 
-    def has_individual_autofix(self, changes):
+    def has_individual_autofix(self, changes: dict[Any, Any]) -> bool:
         # check if we have a dictionary with bug numbers as keys
         # return True if all the keys are bug number
         # (which means that each bug has its own autofix)
-        return changes and all(
+        return bool(changes) and all(
             isinstance(bugid, int) or bugid.isdigit() for bugid in changes
         )
 
-    def get_autofix_change(self):
+    def get_autofix_change(self) -> dict[str, Any]:
         """Get the change to do to autofix the bugs"""
         return self.autofix_changes
 
-    def autofix(self, bugs):
+    def autofix(self, bugs: dict[str, Bug]) -> dict[str, Bug]:
         """Autofix the bugs according to what is returned by get_autofix_change"""
         ni_changes = self.set_needinfo()
         change = self.get_autofix_change()
@@ -584,7 +606,8 @@ class BzCleaner(object):
             return bugs
 
         self.has_autofix = True
-        new_changes = {}
+        new_changes: dict[str, Any] = {}
+        bugids: Iterable[str]
         if not self.has_individual_autofix(change):
             bugids = self.get_list_bugs(bugs)
             for bugid in bugids:
@@ -623,10 +646,10 @@ class BzCleaner(object):
     @staticmethod
     def apply_changes_on_bugzilla(
         rule_name: str,
-        new_changes: Dict[str, dict],
+        new_changes: Mapping[str, dict],
         no_bugmail: bool = False,
         is_dryrun: bool = True,
-        db_extra: Dict[str, str] | None = None,
+        db_extra: Mapping[str, Any] | None = None,
     ) -> None:
         """Apply changes on Bugzilla
 
@@ -671,31 +694,33 @@ class BzCleaner(object):
                     failures,
                 )
 
-    def terminate(self):
+    def terminate(self) -> None:
         """Called when everything is done"""
         return
 
-    def organize(self, bugs):
+    def organize(self, bugs: dict[str, Bug]) -> list[tuple[Any, ...]]:
         return utils.organize(bugs, self.columns(), key=self.sort_columns())
 
-    def add_to_cache(self, bugs):
+    def add_to_cache(self, bugs: dict[str, Bug]) -> None:
         """Add the bug keys to cache"""
         if isinstance(bugs, dict):
             self.cache.add(bugs.keys())
         else:
             self.cache.add(bugs)
 
-    def get_email_data(self, date: str) -> List[dict]:
+    def get_email_data(self, date: str) -> EmailData:
         bugs = self.get_bugs(date=date)
         bugs = self._populate_prioritized_actions(bugs)
         bugs = self.autofix(bugs)
         self.add_to_cache(bugs)
         if not bugs:
-            return []
+            return cast(EmailData, [])
 
         return self.organize(bugs)
 
-    def get_email(self, date: str, data: dict, preamble: str = ""):
+    def get_email(
+        self, date: str, data: EmailData, preamble: str = ""
+    ) -> tuple[str, str]:
         """Get title and body for the email"""
         assert data, "No data to send"
 
@@ -720,7 +745,7 @@ class BzCleaner(object):
         )
         return self.get_email_subject(date), body
 
-    def _send_alert_about_too_many_changes(self, err: TooManyChangesError):
+    def _send_alert_about_too_many_changes(self, err: TooManyChangesError) -> None:
         """Send an alert email when there are too many changes to apply"""
 
         env = Environment(loader=FileSystemLoader("templates"))
@@ -752,7 +777,7 @@ class BzCleaner(object):
             dryrun=self.dryrun,
         )
 
-    def send_email(self, date="today"):
+    def send_email(self, date: str = "today") -> None:
         """Send the email"""
         if date:
             date = lmdutils.get_date(date)
@@ -768,11 +793,11 @@ class BzCleaner(object):
             return
 
         login_info = utils.get_login_info()
-        data = self.get_email_data(date)
-        if data:
-            title, body = self.get_email(date, data)
+        email_data = self.get_email_data(date)
+        if email_data:
+            title, body = self.get_email(date, email_data)
             receivers = utils.get_receivers(self.name())
-            cc_list = self.get_cc_emails(data)
+            cc_list = self.get_cc_emails(email_data)
 
             status = "Success"
             try:
@@ -801,13 +826,13 @@ class BzCleaner(object):
                 logger.info("{}: No data".format(name))
             logger.info("Query: {}".format(self.query_url))
 
-    def add_custom_arguments(self, parser):
+    def add_custom_arguments(self, parser: argparse.ArgumentParser) -> None:
         pass
 
-    def parse_custom_arguments(self, args):
+    def parse_custom_arguments(self, args: argparse.Namespace) -> None:
         pass
 
-    def get_args_parser(self):
+    def get_args_parser(self) -> argparse.ArgumentParser:
         """Get the arguments from the command line"""
         parser = argparse.ArgumentParser(description=self.description())
         parser.add_argument(
@@ -839,7 +864,7 @@ class BzCleaner(object):
 
         return parser
 
-    def run(self):
+    def run(self) -> None:
         """Run the rule"""
         logger_extra["bugbot_rule"] = self.name()
         logger.info("Run rule %s", self.get_rule_path())

--- a/bugbot/bzcleaner.py
+++ b/bugbot/bzcleaner.py
@@ -25,7 +25,7 @@ from bugbot.cache import Cache
 from bugbot.nag_me import Nag
 
 BzParams = dict[str, str | int | list[str] | list[int]]
-EmailData = list[Any | tuple[Any, ...] | dict[Any, Any]]
+EmailData = list[Any] | list[tuple[Any, ...]] | list[dict[Any, Any]]
 Bug = Mapping[str, Any]
 
 
@@ -698,7 +698,7 @@ class BzCleaner(object):
         """Called when everything is done"""
         return
 
-    def organize(self, bugs: dict[str, Bug]) -> list[tuple[Any, ...]]:
+    def organize(self, bugs: dict[str, Bug]) -> list[Any] | list[tuple[Any, ...]]:
         return utils.organize(bugs, self.columns(), key=self.sort_columns())
 
     def add_to_cache(self, bugs: dict[str, Bug]) -> None:

--- a/bugbot/bzcleaner.py
+++ b/bugbot/bzcleaner.py
@@ -25,7 +25,7 @@ from bugbot.cache import Cache
 from bugbot.nag_me import Nag
 
 BzParams = dict[str, str | int | list[str] | list[int]]
-EmailData = list[tuple[Any, ...]] | list[dict[Any, Any]]
+EmailData = list[Any | tuple[Any, ...] | dict[Any, Any]]
 Bug = Mapping[str, Any]
 
 
@@ -299,7 +299,7 @@ class BzCleaner(object):
 
         self.quota_actions[quota_name].append(action)
 
-    def get_bug_sort_key(self, bug: int) -> str | None:
+    def get_bug_sort_key(self, bug: Bug) -> str | None:
         return None
 
     def _populate_prioritized_actions(self, bugs: dict[str, Bug]) -> dict[str, Any]:

--- a/bugbot/rules/triage_owner_rotations.py
+++ b/bugbot/rules/triage_owner_rotations.py
@@ -16,7 +16,7 @@ from tenacity import (
 )
 
 from bugbot import logger
-from bugbot.bzcleaner import BzCleaner
+from bugbot.bzcleaner import BzCleaner, EmailData
 from bugbot.component_triagers import ComponentName, ComponentTriagers, TriageOwner
 from bugbot.utils import get_bug_bugdash_url
 
@@ -103,9 +103,10 @@ class TriageOwnerRotations(BzCleaner):
             for new_triager in new_triagers
         ]
 
-    def get_cc_emails(self, data: List[dict]) -> List[str]:
+    def get_cc_emails(self, data: EmailData) -> List[str]:
         cc_emails = set()
         for entry in data:
+            assert isinstance(entry, dict)
             cc_emails.add(entry.get("old_triage_owner", ""))
             cc_emails.add(entry.get("new_triage_owner", ""))
         return list(cc_emails)

--- a/bugbot/rules/web_platform_features.py
+++ b/bugbot/rules/web_platform_features.py
@@ -2,12 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import urllib
+# mypy: disallow-untyped-defs
+
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping, Optional
+from urllib import parse
 
 from bugbot import gcp
-from bugbot.bzcleaner import BzCleaner
+from bugbot.bzcleaner import Bug, BzCleaner
 
 
 @dataclass
@@ -22,7 +24,7 @@ def url_keys(urls: Iterable[str]) -> Mapping[tuple[str, str], str]:
     rv = {}
     for url in urls:
         try:
-            parsed = urllib.parse.urlparse(url)
+            parsed = parse.urlparse(url)
             if parsed.hostname is None:
                 continue
             rv[(parsed.hostname, parsed.path)] = url
@@ -48,9 +50,7 @@ class WebPlatformFeatures(BzCleaner):
     def columns(self) -> list[str]:
         return ["id", "summary", "added"]
 
-    def handle_bug(
-        self, bug: dict[str, Any], data: dict[str, Any]
-    ) -> Optional[dict[str, Any]]:
+    def handle_bug(self, bug: Bug, data: dict[str, Any]) -> Optional[Bug]:
         features_key = bug["id"]
         bug_id = str(bug["id"])
 
@@ -81,7 +81,7 @@ class WebPlatformFeatures(BzCleaner):
 
         return None
 
-    def get_bz_params(self, date) -> dict[str, str | int | list[str] | list[int]]:
+    def get_bz_params(self, date: str) -> dict[str, str | int | list[str] | list[int]]:
         fields = ["id", "url", "see_also"]
         self.feature_bugs = self.get_feature_bugs()
         return {"include_fields": fields, "id": list(self.feature_bugs.keys())}

--- a/bugbot/rules/webcompat_platform_without_keyword.py
+++ b/bugbot/rules/webcompat_platform_without_keyword.py
@@ -8,13 +8,13 @@ from typing import Any, Optional
 from dateutil import parser
 
 from bugbot import gcp
-from bugbot.bzcleaner import BzCleaner
+from bugbot.bzcleaner import Bug, BzCleaner
 
 
 class WebcompatPlatformWithoutKeyword(BzCleaner):
     normal_changes_max = 200
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.last_bugzilla_import_time: Optional[datetime] = None
 
@@ -32,9 +32,7 @@ class WebcompatPlatformWithoutKeyword(BzCleaner):
             "keywords": {"add": ["webcompat:platform-bug"]},
         }
 
-    def handle_bug(
-        self, bug: dict[str, Any], data: dict[str, Any]
-    ) -> Optional[dict[str, Any]]:
+    def handle_bug(self, bug: Bug, data: dict[str, Any]) -> Optional[Bug]:
         bug_id = str(bug["id"])
 
         # If the bug was updated later than our latest bugzilla data there could be a race,

--- a/bugbot/rules/webcompat_score.py
+++ b/bugbot/rules/webcompat_score.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Iterator, Optional, cast
 
 from bugbot import gcp
-from bugbot.bzcleaner import BzCleaner
+from bugbot.bzcleaner import Bug, BzCleaner
 
 
 @dataclass
@@ -71,9 +71,7 @@ class WebcompatScore(BzCleaner):
 
         return None
 
-    def handle_bug(
-        self, bug: dict[str, Any], data: dict[str, Any]
-    ) -> Optional[dict[str, Any]]:
+    def handle_bug(self, bug: Bug, data: dict[str, Any]) -> Optional[Bug]:
         scored_bugs_key = bug["id"]
         bug_id = str(bug["id"])
 

--- a/bugbot/rules/webcompat_sightline.py
+++ b/bugbot/rules/webcompat_sightline.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping, Optional
 
 from bugbot import gcp
-from bugbot.bzcleaner import BzCleaner
+from bugbot.bzcleaner import Bug, BzCleaner
 
 
 @dataclass(frozen=True)
@@ -36,9 +36,7 @@ class WebcompatSightline(BzCleaner):
     def has_default_products(self) -> bool:
         return False
 
-    def handle_bug(
-        self, bug: dict[str, Any], data: dict[str, Any]
-    ) -> Optional[dict[str, Any]]:
+    def handle_bug(self, bug: Bug, data: dict[str, Any]) -> Optional[Bug]:
         bug_id = str(bug["id"])
         whiteboard = bug["whiteboard"]
 


### PR DESCRIPTION
This makes it possible to implement rules without getting type errors reported from the inferred types on the BzCleaner base class.

Some of the types are currently rather general e.g. modelling things as dict[str, Any] when then in fact have some additional structure. However this seems like a good starting point.

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
