### PR TITLE
Use astral/uv image and UV for commands

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -38,7 +38,7 @@ tasks:
         workerType: ci
         payload:
           maxRunTime: 3600
-          image: python:3.10
+          image: astral/uv:python3.10-trixie
           env:
             TOX_ENV: py310
             COVERALLS_REPO_TOKEN: VWnjgqWLHfmgSQMJPFdIRYIG5ontiAGl6
@@ -48,10 +48,10 @@ tasks:
             - "git clone --quiet ${repository} bugbot &&
               cd bugbot &&
               git -c advice.detachedHead=false checkout ${head_rev} &&
-              pip install --quiet -e '.[test]' &&
-              pre-commit run --all-files --show-diff-on-failure &&
-              tox -e $TOX_ENV &&
-              coveralls"
+              uv sync --quiet --locked --extra test &&
+              uv run pre-commit run --all-files --show-diff-on-failure &&
+              uv run tox -e $TOX_ENV &&
+              uv run coveralls"
         metadata:
           name: bugbot tests
           description: bugbot tests


### PR DESCRIPTION
Switch CI worker image to astral/uv:python3.10-trixie and migrate test setup commands to the UV toolchain.

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
