### PR TITLE
Don't ping on leave-open bugs with webcompat:sitepatch-applied

### DIFF
--- a/bugbot/rules/leave_open_no_activity.py
+++ b/bugbot/rules/leave_open_no_activity.py
@@ -50,7 +50,7 @@ class LeaveOpenNoActivity(BzCleaner):
             "v1": "leave-open",
             "f2": "keywords",
             "o2": "nowordssubstr",
-            "v2": "intermittent,stalled,meta",
+            "v2": "intermittent,stalled,meta,webcompat:sitepatch-applied",
             "f3": "status_whiteboard",
             "o3": "notregexp",
             "v3": r"\[(test|stockwell) disabled.*\]",


### PR DESCRIPTION
When we ship intervention for webcompat bugs, we leave the corresponding bug open as long as the intervention is applied (since the underlying issue isn't fixed). Therefore these bugs are often set to `leave-open` for a long time without new activity. Skip suggesting closing these bugs.

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
