### PR TITLE
Don't nag for WebCompat P1 with low severity in the Web Compatibility product

### DIFF
--- a/bugbot/rules/severity_high_compat_priority.py
+++ b/bugbot/rules/severity_high_compat_priority.py
@@ -47,6 +47,15 @@ class SeverityHighCompatPriority(BzCleaner):
             "f1": "longdesc",
             "o1": "casesubstring",
             "v1": "could you consider increasing the severity of this web compatibility bug?",
+            "n2": 1,
+            "f2": "OP",
+            "f3": "product",
+            "o3": "equals",
+            "v3": "Web Compatibility",
+            "f4": "keywords",
+            "o4": "substring",
+            "v4": "webcompat:site-report",
+            "f5": "CP",
         }
 
         return params


### PR DESCRIPTION
These are triaged in a way that makes severity and Web Compat priority not always aligned, but the focus is on WebCompat Priority when setting fix priorities so the mismatch isn't a problem.

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
