### PR TITLE
Update moved_to_performance rule for new Bugzilla components

### DIFF
--- a/bugbot/rules/moved_to_performance.py
+++ b/bugbot/rules/moved_to_performance.py
@@ -16,15 +16,15 @@ from bugbot.bzcleaner import BzCleaner
 # computed in `handle_bug`) that we expect to find; if all of them are already
 # present, we don't need to add a comment.
 PERFORMANCE_COMPONENTS = {
-    "Performance: General": (
+    "Performance: General": {
         "has_profiler_link",
         "has_memory_report",
         "has_troubleshooting_info",
-    ),
-    "Performance: Memory": ("has_memory_report",),
-    "Performance: Navigation": ("has_profiler_link",),
-    "Performance: Responsiveness": ("has_profiler_link",),
-    "Performance: Startup": ("has_profiler_link",),
+    },
+    "Performance: Memory": {"has_memory_report"},
+    "Performance: Navigation": {"has_profiler_link"},
+    "Performance: Responsiveness": {"has_profiler_link"},
+    "Performance: Startup": {"has_profiler_link"},
 }
 
 
@@ -54,10 +54,7 @@ class MovedToPerformance(BzCleaner):
         bugid = str(bug["id"])
 
         component = bug["component"]
-        required_info = PERFORMANCE_COMPONENTS.get(component)
-        if required_info is None:
-            # The bug is in a component we don't have a template for
-            return None
+        required_info = PERFORMANCE_COMPONENTS[component]
 
         has_profiler_link = any(
             "https://share.firefox.dev/" in comment["text"]

--- a/bugbot/rules/moved_to_performance.py
+++ b/bugbot/rules/moved_to_performance.py
@@ -11,9 +11,25 @@ from libmozdata import utils as lmdutils
 
 from bugbot.bzcleaner import BzCleaner
 
+# The performance components we monitor, mapped to the information we request
+# when a bug is moved into them. Each entry lists the keys (from the flags
+# computed in `handle_bug`) that we expect to find; if all of them are already
+# present, we don't need to add a comment.
+PERFORMANCE_COMPONENTS = {
+    "Performance: General": (
+        "has_profiler_link",
+        "has_memory_report",
+        "has_troubleshooting_info",
+    ),
+    "Performance: Memory": ("has_memory_report",),
+    "Performance: Navigation": ("has_profiler_link",),
+    "Performance: Responsiveness": ("has_profiler_link",),
+    "Performance: Startup": ("has_profiler_link",),
+}
+
 
 class MovedToPerformance(BzCleaner):
-    """Add a comment to bugs that recently moved to the performance component"""
+    """Add a comment to bugs that recently moved to a performance component"""
 
     def __init__(self, recent_date_weeks: int = 26):
         """Constructor
@@ -29,13 +45,19 @@ class MovedToPerformance(BzCleaner):
         )
 
     def description(self):
-        return "Bugs that recently moved to the performance component"
+        return "Bugs that recently moved to a performance component"
 
     def get_extra_for_needinfo_template(self):
         return self.ni_extra
 
     def handle_bug(self, bug, data):
         bugid = str(bug["id"])
+
+        component = bug["component"]
+        required_info = PERFORMANCE_COMPONENTS.get(component)
+        if required_info is None:
+            # The bug is in a component we don't have a template for
+            return None
 
         has_profiler_link = any(
             "https://share.firefox.dev/" in comment["text"]
@@ -62,15 +84,18 @@ class MovedToPerformance(BzCleaner):
             and not attachment["is_patch"]
         )
 
-        if has_profiler_link and has_memory_report and has_troubleshooting_info:
-            # Nothing missing, no need to add a comment
-            return None
-
-        self.ni_extra[bugid] = {
+        info = {
+            "component": component,
             "has_profiler_link": has_profiler_link,
             "has_memory_report": has_memory_report,
             "has_troubleshooting_info": has_troubleshooting_info,
         }
+
+        if all(info[key] for key in required_info):
+            # Nothing missing for this component, no need to add a comment
+            return None
+
+        self.ni_extra[bugid] = info
 
         return bug
 
@@ -124,6 +149,7 @@ class MovedToPerformance(BzCleaner):
     def get_bz_params(self, date):
         fields = [
             "creator",
+            "component",
             "attachments.is_obsolete",
             "attachments.is_patch",
             "attachments.content_type",
@@ -145,8 +171,8 @@ class MovedToPerformance(BzCleaner):
             "o1": "equals",
             "v1": "Core",
             "f2": "component",
-            "o2": "equals",
-            "v2": "Performance",
+            "o2": "anyexact",
+            "v2": list(PERFORMANCE_COMPONENTS),
             "f3": "component",
             "o3": "changedafter",
             "v3": "-7d",

--- a/configs/rules.json
+++ b/configs/rules.json
@@ -260,7 +260,6 @@
       "Firefox::Untriaged",
       "Core::JavaScript Engine",
       "DevTools::Accessibility Tools",
-      "Core::Performance",
       "Core::Privacy: Anti-Tracking",
       "Firefox::Extension Compatibility",
       "Core::DOM: Bindings (WebIDL)",

--- a/templates/moved_to_performance.html
+++ b/templates/moved_to_performance.html
@@ -1,5 +1,5 @@
 <p>
-    The following {{ plural('bug was', data, pword='bugs were') }} moved into the Core::Performance component; a comment to request more information was added:
+    The following {{ plural('bug was', data, pword='bugs were') }} moved into a performance component; a comment to request more information was added:
 </p>
 <table {{ table_attrs }}>
     <thead>

--- a/templates/moved_to_performance_needinfo.txt
+++ b/templates/moved_to_performance_needinfo.txt
@@ -1,17 +1,27 @@
-This bug was moved into the Performance component.
+{% set component = extra[bugid]["component"] -%}
+This bug was moved into the {{ component }} component.
 
 :{{ nickname }}, could you make sure the following information is on this bug?
-
+{% if component == "Performance: General" %}
 - {% if extra[bugid]["has_profiler_link"] %}~~✅ {% endif -%}
-For slowness or high CPU usage, capture a profile with http://profiler.firefox.com/, upload it and share the link here.
+For slowness or high CPU usage, capture a profile with https://profiler.firefox.com/, upload it and share the link here.
 {%- if extra[bugid]["has_profiler_link"] %}~~{% endif %}
 - {% if extra[bugid]["has_memory_report"] %}~~✅ {% endif -%}
-For memory usage issues, capture a memory dump from `about:memory` and attach it to this bug.
+For memory usage issues, capture a memory dump from `about:memory` and attach it to this bug. Please consider moving this issue to the Performance: Memory component.
 {%- if extra[bugid]["has_memory_report"] %}~~{% endif %}
 - {% if extra[bugid]["has_troubleshooting_info"] %}~~✅ {% endif -%}
 Troubleshooting information: Go to `about:support`, click "Copy raw data to clipboard", paste it into a file, save it, and attach the file here.
 {% if extra[bugid]["has_troubleshooting_info"] %}~~{% endif %}
-
 If the requested information is already in the bug, please confirm it is recent.
+{% elif component == "Performance: Memory" %}
+Please go to `about:memory`, there you can see a button labeled "Measure and save", you can use this to save a memory report that you can attach to this bug. Note that a memory report can contain information about the websites you are visiting and may be anonymized by the checkbox next to the button.
+{% elif component == "Performance: Navigation" %}
+If the problem is reproducible for you, please capture a profile with the Firefox Profiler. The instructions can be found at https://profiler.firefox.com/. Start the profiler before executing the navigation and capture the profile after the full navigation has finished.
 
+Please use the upload button in the top right to upload the profile. If you are comfortable sharing additional diagnostic information, please check "Include additional data that may be identifiable" when presented with the upload options. This extra data can help us diagnose the problem.
+{% elif component == "Performance: Responsiveness" %}
+If the problem is reproducible for you, please capture a profile with the Firefox Profiler. The instructions can be found at https://profiler.firefox.com/. Start the profiler before executing the interaction suffering from responsiveness issues and capture the profile after the full interaction has finished. Please use the upload link at the top right and share the link on this bug to help with diagnosis.
+{% elif component == "Performance: Startup" %}
+Startup issues can be very difficult for our engineers to reproduce. If the problem is reproducible for you, please capture a profile with the Firefox Profiler. The instructions for profiling startup can be found at https://profiler.firefox.com/docs/#/./guide-startup-shutdown. After successfully capturing a profile, please upload it using the link at the top right and share the link on this bug to help with diagnosis.
+{% endif %}
 Thank you.

--- a/templates/moved_to_performance_needinfo.txt
+++ b/templates/moved_to_performance_needinfo.txt
@@ -4,14 +4,12 @@ This bug was moved into the {{ component }} component.
 :{{ nickname }}, could you make sure the following information is on this bug?
 {% if component == "Performance: General" %}
 - {% if extra[bugid]["has_profiler_link"] %}~~✅ {% endif -%}
-For slowness or high CPU usage, capture a profile with https://profiler.firefox.com/, upload it and share the link here.
-{%- if extra[bugid]["has_profiler_link"] %}~~{% endif %}
+For slowness or high CPU usage, capture a profile with https://profiler.firefox.com/, upload it and share the link here.{% if extra[bugid]["has_profiler_link"] %}~~{% endif %}
 - {% if extra[bugid]["has_memory_report"] %}~~✅ {% endif -%}
-For memory usage issues, capture a memory dump from `about:memory` and attach it to this bug. Please consider moving this issue to the Performance: Memory component.
-{%- if extra[bugid]["has_memory_report"] %}~~{% endif %}
+For memory usage issues, capture a memory dump from `about:memory` and attach it to this bug. Please consider moving this issue to the Performance: Memory component.{% if extra[bugid]["has_memory_report"] %}~~{% endif %}
 - {% if extra[bugid]["has_troubleshooting_info"] %}~~✅ {% endif -%}
-Troubleshooting information: Go to `about:support`, click "Copy raw data to clipboard", paste it into a file, save it, and attach the file here.
-{% if extra[bugid]["has_troubleshooting_info"] %}~~{% endif %}
+Troubleshooting information: Go to `about:support`, click "Copy raw data to clipboard", paste it into a file, save it, and attach the file here.{% if extra[bugid]["has_troubleshooting_info"] %}~~{% endif %}
+
 If the requested information is already in the bug, please confirm it is recent.
 {% elif component == "Performance: Memory" %}
 Please go to `about:memory`, there you can see a button labeled "Measure and save", you can use this to save a memory report that you can attach to this bug. Note that a memory report can contain information about the websites you are visiting and may be anonymized by the checkbox next to the button.


### PR DESCRIPTION
Core::Performance was split into Performance: General, Memory, Navigation, Responsiveness, and Startup. Target all five components, send a component-specific needinfo template, and keep the adaptive detection that skips bugs already containing the requested info.

Also remove Core::Performance from the workflow components_skiplist.

Closes #2683

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
