### PR TITLE
Move uplift_beta rule from weekday to hourly cron

### DIFF
--- a/scripts/cron_run_hourly.sh
+++ b/scripts/cron_run_hourly.sh
@@ -38,6 +38,9 @@ python -m bugbot.rules.stalled --production
 # Pretty rare
 python -m bugbot.rules.missing_beta_status --production
 
+# Needinfo assignee when a patch could be uplifted to beta
+python -m bugbot.rules.uplift_beta --production
+
 # File bugs for new actionable crashes
 python -m bugbot.rules.file_crash_bug --production
 

--- a/scripts/cron_run_weekdays.sh
+++ b/scripts/cron_run_weekdays.sh
@@ -20,10 +20,6 @@ python -m bugbot.rules.reminder --production
 # Daily
 python -m bugbot.round_robin_fallback --production
 
-# Needinfo assignee when a patch could be uplifted to beta
-# Daily
-python -m bugbot.rules.uplift_beta --production
-
 # What is fixed in nightly but affecting beta or release
 # Daily
 python -m bugbot.rules.missed_uplifts --production


### PR DESCRIPTION
Run the uplift_beta rule hourly instead of once per weekday so newly-eligible bugs are picked up sooner. The rule's existing anti-renag filter prevents duplicate needinfos across runs.

<!---
Please describe why and what this Pull Request is doing
-->

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
