### PR TITLE
Add ESR affected checks to the uplift request rule

### DIFF
--- a/bugbot/rules/uplift_beta.py
+++ b/bugbot/rules/uplift_beta.py
@@ -21,6 +21,11 @@ class UpliftBeta(BzCleaner):
         )
         self.status_beta = utils.get_flag(self.beta, "status", "beta")
 
+        # The needinfo mentions ESR generically, so we only need the current
+        # ESR's status flag to tell whether ESR is affected.
+        self.esr = self.versions["esr"]
+        self.status_esr = utils.get_flag(self.esr, "status", "esr")
+
         # Bugs will be added to `extra_ni` later after being fetched
         self.extra_ni = {"status_beta": f"status-firefox{self.beta}"}
 
@@ -49,12 +54,17 @@ class UpliftBeta(BzCleaner):
         if self.is_needinfo_on_assignee(bug.get("flags", []), assignee):
             return None
 
+        # Flag ESR using the same criteria as beta (see get_bz_params): both
+        # "affected" and "fix-optional" should prompt about an uplift.
+        esr_affected = bug.get(self.status_esr) in ("affected", "fix-optional")
+
         data[bugid] = {
             "id": bugid,
             "mail": assignee,
             "nickname": nickname,
             "summary": self.get_summary(bug),
             "regressions": bug["regressions"],
+            "esr_affected": esr_affected,
         }
 
         return bug
@@ -98,6 +108,7 @@ class UpliftBeta(BzCleaner):
         self.date = lmdutils.get_date_ymd(date)
         fields = [
             self.status_beta,
+            self.status_esr,
             "regressions",
             "attachments.creation_time",
             "attachments.is_obsolete",
@@ -143,7 +154,10 @@ class UpliftBeta(BzCleaner):
 
         for bugid, data in bugs.items():
             if data["mail"] and data["nickname"]:
-                self.extra_ni[bugid] = {"regression": len(data["regressions"])}
+                self.extra_ni[bugid] = {
+                    "regression": len(data["regressions"]),
+                    "esr_affected": data["esr_affected"],
+                }
                 self.add_auto_ni(
                     bugid, {"mail": data["mail"], "nickname": data["nickname"]}
                 )

--- a/templates/uplift_beta_needinfo.txt
+++ b/templates/uplift_beta_needinfo.txt
@@ -1,7 +1,7 @@
-The patch landed in nightly and beta is affected.
+The patch landed in nightly and beta is affected{% if extra[bugid]["esr_affected"] %}, along with ESR{% endif %}.
 :{{ nickname }}, is this bug important enough to require an uplift?
-- If yes, please nominate the patch for beta approval.{% if extra[bugid]["regression"] %} Also, don't forget to request an uplift for the patches in the {{ plural('regression', extra[bugid]["regression"]) }} caused by this fix.{% endif %}
+- If yes, please nominate the patch for {% if extra[bugid]["esr_affected"] %}beta and ESR approvals{% else %}beta approval{% endif %}.{% if extra[bugid]["regression"] %} Also, don't forget to request an uplift for the patches in the {{ plural('regression', extra[bugid]["regression"]) }} caused by this fix.{% endif %}
   - See https://wiki.mozilla.org/Release_Management/Requesting_an_Uplift for documentation on how to request an uplift.
-- If no, please set `{{ extra["status_beta"] }}` to `wontfix`.
+- If no, please set {% if extra[bugid]["esr_affected"] %}`{{ extra["status_beta"] }}` and the ESR status flag(s){% else %}`{{ extra["status_beta"] }}`{% endif %} to `wontfix`.
 
 {{ documentation }}


### PR DESCRIPTION
We never prompt to create an ESR uplift request when creating a need-info to add a Beta uplift request. 
This PR adds prompting to create an ESR uplift IF already creating a need-info to a beta uplift request prompt AND the current ESR version is affected

## Checklist

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
