### PR TITLE
Add Focus and GeckView to NON_ESR_PRODUCTS in security_affected_versions

### DIFF
--- a/bugbot/rules/security_affected_versions.py
+++ b/bugbot/rules/security_affected_versions.py
@@ -25,7 +25,7 @@ NEEDINFO_QUESTION = (
 
 # Products that don't ship on ESR, so their ESR status flags are never set and
 # must not be treated as a "missing" flag worth nagging about.
-NON_ESR_PRODUCTS = {"Firefox for Android"}
+NON_ESR_PRODUCTS = {"Firefox for Android", "Focus", "GeckoView"}
 
 
 class SecurityAffectedVersions(BzCleaner):


### PR DESCRIPTION
The NON_ESR_PRODUCTS list for sec bug versions should also include the Focus and GeckoView products

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [x] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
