### PR TITLE
Change perf and telemetry alert inactivity time to 3 days.

### DIFF
--- a/bugbot/rules/perfalert_inactive_regression.py
+++ b/bugbot/rules/perfalert_inactive_regression.py
@@ -12,14 +12,14 @@ from bugbot.user_activity import UserActivity, UserStatus
 
 
 class PerfAlertInactiveRegression(BzCleaner):
-    def __init__(self, nweeks=1):
+    def __init__(self, ndays=3):
         super().__init__()
-        self.nweeks = nweeks
-        self.extra_ni = {"nweeks": self.nweeks}
+        self.ndays = ndays
+        self.extra_ni = {"ndays": self.ndays}
         self.private_regressor_ids: set[str] = set()
 
     def description(self):
-        return f"PerfAlert regressions with {self.nweeks} week(s) of inactivity"
+        return f"PerfAlert regressions with {self.ndays} day(s) of inactivity"
 
     def handle_bug(self, bug, data):
         if len(bug["regressed_by"]) != 1:
@@ -59,7 +59,7 @@ class PerfAlertInactiveRegression(BzCleaner):
             "v4": "backlog-deferred",
             "f5": "days_elapsed",
             "o5": "greaterthan",
-            "v5": self.nweeks * 7,
+            "v5": self.ndays,
             "status": ["UNCONFIRMED", "NEW", "REOPENED"],
             "resolution": ["---"],
         }

--- a/bugbot/rules/perfalert_inactive_regression.py
+++ b/bugbot/rules/perfalert_inactive_regression.py
@@ -4,6 +4,8 @@
 
 import collections
 
+import numpy
+from libmozdata import utils as lmdutils
 from libmozdata.bugzilla import Bugzilla
 
 from bugbot import logger, utils
@@ -18,6 +20,11 @@ class PerfAlertInactiveRegression(BzCleaner):
         self.extra_ni = {"ndays": self.ndays}
         self.private_regressor_ids: set[str] = set()
 
+        # Bugs last changed after this are not yet inactive long enough
+        self.activity_date = str(
+            numpy.busday_offset(lmdutils.get_date("today"), -self.ndays)
+        )
+
     def description(self):
         return f"PerfAlert regressions with {self.ndays} day(s) of inactivity"
 
@@ -25,6 +32,10 @@ class PerfAlertInactiveRegression(BzCleaner):
         if len(bug["regressed_by"]) != 1:
             # either we don't have access to the regressor,
             # or there's more than one, either way leave things alone
+            return
+
+        # `last_change_time` is a full timestamp, so compare only its date part
+        if bug["last_change_time"][:10] > self.activity_date:
             return
 
         data[str(bug["id"])] = {
@@ -39,6 +50,7 @@ class PerfAlertInactiveRegression(BzCleaner):
         fields = [
             "id",
             "regressed_by",
+            "last_change_time",
         ]
 
         # Find all bugs that have perf-alert, and regression in their keywords. Only
@@ -58,7 +70,7 @@ class PerfAlertInactiveRegression(BzCleaner):
             "o4": "nowords",
             "v4": "backlog-deferred",
             "f5": "days_elapsed",
-            "o5": "greaterthan",
+            "o5": "greaterthaneq",
             "v5": self.ndays,
             "status": ["UNCONFIRMED", "NEW", "REOPENED"],
             "resolution": ["---"],

--- a/bugbot/rules/perfalert_inactive_regression.py
+++ b/bugbot/rules/perfalert_inactive_regression.py
@@ -30,10 +30,13 @@ class PerfAlertInactiveRegression(BzCleaner):
             return
 
         # Skip bugs that haven't been inactive for enough business days
-        if numpy.busday_count(
-            lmdutils.get_date_ymd(bug["last_change_time"]).date(),
-            lmdutils.get_date("today"),
-        ) <= self.ndays:
+        if (
+            numpy.busday_count(
+                lmdutils.get_date_ymd(bug["last_change_time"]).date(),
+                lmdutils.get_date("today"),
+            )
+            <= self.ndays
+        ):
             return
 
         data[str(bug["id"])] = {

--- a/bugbot/rules/perfalert_inactive_regression.py
+++ b/bugbot/rules/perfalert_inactive_regression.py
@@ -20,11 +20,6 @@ class PerfAlertInactiveRegression(BzCleaner):
         self.extra_ni = {"ndays": self.ndays}
         self.private_regressor_ids: set[str] = set()
 
-        # Bugs last changed after this are not yet inactive long enough
-        self.activity_date = str(
-            numpy.busday_offset(lmdutils.get_date("today"), -self.ndays)
-        )
-
     def description(self):
         return f"PerfAlert regressions with {self.ndays} day(s) of inactivity"
 
@@ -34,8 +29,11 @@ class PerfAlertInactiveRegression(BzCleaner):
             # or there's more than one, either way leave things alone
             return
 
-        # `last_change_time` is a full timestamp, so compare only its date part
-        if bug["last_change_time"][:10] > self.activity_date:
+        # Skip bugs that haven't been inactive for enough business days
+        if numpy.busday_count(
+            lmdutils.get_date_ymd(bug["last_change_time"]).date(),
+            lmdutils.get_date("today"),
+        ) <= self.ndays:
             return
 
         data[str(bug["id"])] = {

--- a/bugbot/rules/telemetryalert_inactive_regression.py
+++ b/bugbot/rules/telemetryalert_inactive_regression.py
@@ -82,10 +82,13 @@ class TelemetryAlertInactiveRegression(BzCleaner):
 
     def handle_bug(self, bug, data):
         # Skip bugs that haven't been inactive for enough business days
-        if numpy.busday_count(
-            lmdutils.get_date_ymd(bug["last_change_time"]).date(),
-            lmdutils.get_date("today"),
-        ) <= self.ndays:
+        if (
+            numpy.busday_count(
+                lmdutils.get_date_ymd(bug["last_change_time"]).date(),
+                lmdutils.get_date("today"),
+            )
+            <= self.ndays
+        ):
             return
 
         probe_owner = self.get_probe_owner(bug["history"])

--- a/bugbot/rules/telemetryalert_inactive_regression.py
+++ b/bugbot/rules/telemetryalert_inactive_regression.py
@@ -10,13 +10,13 @@ from bugbot.user_activity import UserActivity, UserStatus
 
 
 class TelemetryAlertInactiveRegression(BzCleaner):
-    def __init__(self, nweeks=1):
+    def __init__(self, ndays=3):
         super().__init__()
-        self.nweeks = nweeks
-        self.extra_ni = {"nweeks": self.nweeks}
+        self.ndays = ndays
+        self.extra_ni = {"ndays": self.ndays}
 
     def description(self):
-        return f"Telemetry alerts with {self.nweeks} week(s) of inactivity"
+        return f"Telemetry alerts with {self.ndays} day(s) of inactivity"
 
     def get_extra_for_needinfo_template(self):
         return self.extra_ni
@@ -33,7 +33,7 @@ class TelemetryAlertInactiveRegression(BzCleaner):
         ]
 
         # Find all bugs that have a telemetry-alert keyword, have not changed in the
-        # last week, and do not have the backlog-deferred keyword set
+        # last few days, and do not have the backlog-deferred keyword set
         params = {
             "include_fields": fields,
             "f3": "keywords",
@@ -44,7 +44,7 @@ class TelemetryAlertInactiveRegression(BzCleaner):
             "v4": "backlog-deferred",
             "f5": "days_elapsed",
             "o5": "greaterthan",
-            "v5": self.nweeks * 7,
+            "v5": self.ndays,
             "status": ["UNCONFIRMED", "NEW", "REOPENED"],
             "resolution": ["---"],
         }

--- a/bugbot/rules/telemetryalert_inactive_regression.py
+++ b/bugbot/rules/telemetryalert_inactive_regression.py
@@ -3,6 +3,8 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
+import numpy
+from libmozdata import utils as lmdutils
 from libmozdata.bugzilla import BugzillaUser
 
 from bugbot.bzcleaner import BzCleaner
@@ -14,6 +16,11 @@ class TelemetryAlertInactiveRegression(BzCleaner):
         super().__init__()
         self.ndays = ndays
         self.extra_ni = {"ndays": self.ndays}
+
+        # Bugs last changed after this are not yet inactive long enough
+        self.activity_date = str(
+            numpy.busday_offset(lmdutils.get_date("today"), -self.ndays)
+        )
 
     def description(self):
         return f"Telemetry alerts with {self.ndays} day(s) of inactivity"
@@ -30,6 +37,7 @@ class TelemetryAlertInactiveRegression(BzCleaner):
         fields = [
             "id",
             "history",
+            "last_change_time",
         ]
 
         # Find all bugs that have a telemetry-alert keyword, have not changed in the
@@ -43,7 +51,7 @@ class TelemetryAlertInactiveRegression(BzCleaner):
             "o4": "nowords",
             "v4": "backlog-deferred",
             "f5": "days_elapsed",
-            "o5": "greaterthan",
+            "o5": "greaterthaneq",
             "v5": self.ndays,
             "status": ["UNCONFIRMED", "NEW", "REOPENED"],
             "resolution": ["---"],
@@ -78,6 +86,10 @@ class TelemetryAlertInactiveRegression(BzCleaner):
         return probe_owner
 
     def handle_bug(self, bug, data):
+        # `last_change_time` is a full timestamp, so compare only its date part.
+        if bug["last_change_time"][:10] > self.activity_date:
+            return
+
         probe_owner = self.get_probe_owner(bug["history"])
         if not probe_owner:
             # Could not find a probe owner for some reason

--- a/bugbot/rules/telemetryalert_inactive_regression.py
+++ b/bugbot/rules/telemetryalert_inactive_regression.py
@@ -17,11 +17,6 @@ class TelemetryAlertInactiveRegression(BzCleaner):
         self.ndays = ndays
         self.extra_ni = {"ndays": self.ndays}
 
-        # Bugs last changed after this are not yet inactive long enough
-        self.activity_date = str(
-            numpy.busday_offset(lmdutils.get_date("today"), -self.ndays)
-        )
-
     def description(self):
         return f"Telemetry alerts with {self.ndays} day(s) of inactivity"
 
@@ -86,8 +81,11 @@ class TelemetryAlertInactiveRegression(BzCleaner):
         return probe_owner
 
     def handle_bug(self, bug, data):
-        # `last_change_time` is a full timestamp, so compare only its date part.
-        if bug["last_change_time"][:10] > self.activity_date:
+        # Skip bugs that haven't been inactive for enough business days
+        if numpy.busday_count(
+            lmdutils.get_date_ymd(bug["last_change_time"]).date(),
+            lmdutils.get_date("today"),
+        ) <= self.ndays:
             return
 
         probe_owner = self.get_probe_owner(bug["history"])

--- a/templates/perfalert_inactive_regression.html
+++ b/templates/perfalert_inactive_regression.html
@@ -1,5 +1,5 @@
 <p>
-    The following {{ plural('bug is a performance alert which has had', data, pword='bugs are performance alerts which have had') }} no activity in the last {{ extra['nweeks'] * 7 }} days:
+    The following {{ plural('bug is a performance alert which has had', data, pword='bugs are performance alerts which have had') }} no activity in the last {{ extra['ndays'] }} days:
 </p>
 <table {{ table_attrs }}>
     <thead>

--- a/templates/perfalert_inactive_regression_needinfo.txt
+++ b/templates/perfalert_inactive_regression_needinfo.txt
@@ -1,4 +1,4 @@
-It has been over {{ extra["nweeks"] * 7 }} days with no activity on this performance regression.
+It has been over {{ extra["ndays"] }} days with no activity on this performance regression.
 
 :{{ nickname }}, since you are the author of the regressor, bug {{ extra[bugid]["regressor_id"] }}, which triggered this performance alert, could you please provide a progress update?
 

--- a/templates/telemetryalert_inactive_regression.html
+++ b/templates/telemetryalert_inactive_regression.html
@@ -1,5 +1,5 @@
 <p>
-    The following {{ plural('bug is a telemetry alert which has had', data, pword='bugs are telemetry alerts which have had') }} no activity in the last {{ extra['nweeks'] * 7 }} days:
+    The following {{ plural('bug is a telemetry alert which has had', data, pword='bugs are telemetry alerts which have had') }} no activity in the last {{ extra['ndays'] }} days:
 </p>
 <table {{ table_attrs }}>
     <thead>

--- a/templates/telemetryalert_inactive_regression_needinfo.txt
+++ b/templates/telemetryalert_inactive_regression_needinfo.txt
@@ -1,4 +1,4 @@
-It has been over {{ extra["nweeks"] * 7 }} days with no activity on this telemetry alert.
+It has been over {{ extra["ndays"] }} days with no activity on this telemetry alert.
 
 :{{ nickname }}, since you are the owner of the probe that alerted, could you please provide a progress update?
 


### PR DESCRIPTION
This patch changes the inactivity time to 3 days for performance and telemetry alerts.