### PR TITLE
Move the security_affected_versions rule to the hourly cron

### DIFF
--- a/scripts/cron_run_hourly.sh
+++ b/scripts/cron_run_hourly.sh
@@ -30,6 +30,10 @@ python -m bugbot.rules.summary_meta_missing --production
 # Pretty common
 python -m bugbot.rules.nightly_reopened --production
 
+# Needinfo for security bugs with a patch but a missing release status flag
+# Pretty common
+python -m bugbot.rules.security_affected_versions --production
+
 # Bug closed with the stalled keyword
 # Pretty rare
 python -m bugbot.rules.stalled --production

--- a/scripts/cron_run_weekdays.sh
+++ b/scripts/cron_run_weekdays.sh
@@ -139,9 +139,6 @@ python -m bugbot.rules.severity_inconsistency --production
 # Needinfo for bugs with high security keywords whose set to low severity
 python -m bugbot.rules.severity_high_security --production
 
-# Needinfo for security bugs with a patch but a missing release status flag
-python -m bugbot.rules.security_affected_versions --production
-
 # Nag for components that need triage owner to be assigned
 python -m bugbot.rules.vacant_triage_owner --production
 


### PR DESCRIPTION
The rule has been live for the last 2 weeks and has been very useful.
The weekday cron frequency leaves gaps from early Friday; moving to hourly will improve the engineer context and remove the coverage gap for the rule.

## Checklist

<!---
The following should be done (and marked as completed) when applicable. Please do not remove inapplicable items.
-->

- [ ] Type annotations added to new functions
- [ ] Docs added to functions touched in main classes
- [ ] Dry-run produced the expected results
- [ ] The [`to-be-announced`](https://github.com/mozilla/bugbot/labels/to-be-announced) tag added if this is worth announcing
